### PR TITLE
Include command and stderr in test listing error message

### DIFF
--- a/src/testcommand.rs
+++ b/src/testcommand.rs
@@ -218,9 +218,10 @@ impl TestCommand {
             })?;
 
         if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(Error::CommandExecution(format!(
-                "Test listing command failed with exit code: {}",
-                output.status
+                "Test listing command failed with exit code: {}\nCommand: {}\nStderr:\n{}",
+                output.status, cmd, stderr
             )));
         }
 


### PR DESCRIPTION
When list_tests fails, the error now shows the command that was run and its stderr output, making it much easier to diagnose issues.