### PR TITLE
Skip slow-test warnings for sub-millisecond tests

### DIFF
--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -1,6 +1,8 @@
 //! Utility functions for command implementation
 
-use crate::config::{CONFIG_FILE_NAMES, SLOW_TEST_WARNING_MULTIPLIER};
+use crate::config::{
+    CONFIG_FILE_NAMES, SLOW_TEST_WARNING_MIN_DURATION, SLOW_TEST_WARNING_MULTIPLIER,
+};
 use crate::error::Result;
 use crate::repository::inquest::InquestRepositoryFactory;
 #[cfg(feature = "testr")]
@@ -223,6 +225,9 @@ pub fn warn_slow_tests(
         .values()
         .filter_map(|result| {
             let actual = result.duration?;
+            if actual < SLOW_TEST_WARNING_MIN_DURATION {
+                return None;
+            }
             let historical = historical_times.get(&result.test_id)?;
             let threshold = std::time::Duration::from_secs_f64(
                 historical.as_secs_f64() * SLOW_TEST_WARNING_MULTIPLIER,
@@ -512,6 +517,23 @@ mod tests {
         let output = ui.output.join("\n");
         assert!(output.contains("slow_test"), "got: {}", output);
         assert!(output.contains("slower"), "got: {}", output);
+    }
+
+    #[test]
+    fn test_warn_slow_tests_ignores_very_fast_tests() {
+        let mut ui = crate::ui::test_ui::TestUI::new();
+        let mut run = crate::repository::TestRun::new(crate::repository::RunId::new("0"));
+        run.add_result(
+            crate::repository::TestResult::success("fast_test")
+                .with_duration(std::time::Duration::from_micros(500)),
+        );
+        let mut historical = std::collections::HashMap::new();
+        historical.insert(
+            crate::repository::TestId::new("fast_test"),
+            std::time::Duration::from_micros(10),
+        );
+        warn_slow_tests(&mut ui, &run, &historical).unwrap();
+        assert!(ui.output.is_empty());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,11 @@ pub const MAX_TEST_TIMEOUT_RESTARTS: usize = 10;
 /// multiple of its historical average duration.
 pub const SLOW_TEST_WARNING_MULTIPLIER: f64 = 3.0;
 
+/// Minimum absolute duration for a test to be considered for slow-test warnings.
+/// Tests faster than this are treated as noise even if they exceed the multiplier,
+/// since small absolute variations produce huge ratios on sub-second tests.
+pub const SLOW_TEST_WARNING_MIN_DURATION: std::time::Duration = std::time::Duration::from_millis(2);
+
 /// Timeout configuration that supports "disabled", "auto", or an explicit duration.
 ///
 /// Used for both per-test timeouts and overall run timeouts.


### PR DESCRIPTION
Tests that run in near-zero time produced useless "infx slower" reports, since a 3x threshold on a 1ms test is just timing noise. Add a 2ms absolute floor below which slow-test warnings are suppressed.