### PR TITLE
Restart test runner on crashes with in-progress test blame

### DIFF
--- a/doc/src/running-tests.md
+++ b/doc/src/running-tests.md
@@ -94,6 +94,35 @@ filtering by test ID (`$IDOPTION`/`$IDFILE`/`$IDLIST` in the command),
 inq restarts the runner with the remaining tests. Otherwise the run
 stops.
 
+### Restarting after a crash
+
+If the test runner exits with a non-success status while one or more
+tests are still in progress (a panic, segfault, or other abnormal
+termination), inq treats this as a crash rather than a normal failing
+run. The in-flight tests are recorded as errors ("test runner exited
+while this test was running"), and — provided the test command supports
+filtering by test ID — inq restarts the runner with the remaining
+tests.
+
+Restart-on-crash only fires when forward progress was made: if the
+first test in a partition crashes the runner without any other test
+completing, inq stops instead of looping. An ordinary failing run,
+where all tests completed and the runner just exits non-zero because
+of the failures, is not treated as a crash and does not trigger a
+restart.
+
+### Maximum number of restarts (`--max-restarts`)
+
+Both timeout and crash restarts share a single budget, defaulting to
+10 restarts per run. Override it with:
+
+```sh
+  $ inq run --max-restarts 3
+```
+
+Once the budget is exhausted, inq stops restarting and reports whatever
+results it has so far.
+
 ### Overall run timeout (`--max-duration`)
 
 Kills the entire test run if it exceeds the given duration:

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -58,6 +58,8 @@ pub struct RunCommand {
     pub max_duration: TimeoutSetting,
     /// Kill test if no output for this duration
     pub no_output_timeout: Option<Duration>,
+    /// Maximum number of restarts on timeout or crash (None = default).
+    pub max_restarts: Option<usize>,
 }
 
 impl RunCommand {
@@ -85,6 +87,7 @@ impl RunCommand {
             all_output: self.all_output,
             test_args: self.test_args.clone(),
             cancellation_token: None,
+            max_restarts: self.max_restarts,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,9 +24,10 @@ pub const AUTO_MAX_DURATION_MINIMUM: Duration = Duration::from_secs(60);
 /// Interval between polls when waiting for a child process with a timeout.
 pub const TIMEOUT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-/// Maximum number of times a test process can be restarted due to per-test
-/// timeouts before giving up. Prevents infinite restart loops when many tests hang.
-pub const MAX_TEST_TIMEOUT_RESTARTS: usize = 10;
+/// Maximum number of times a test process can be restarted (due to per-test
+/// timeouts or crashes) before giving up. Prevents infinite restart loops when
+/// many tests hang or the runner keeps crashing.
+pub const MAX_TEST_RESTARTS: usize = 10;
 
 /// Multiplier for slow test warnings: warn if a test takes longer than this
 /// multiple of its historical average duration.

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,6 +224,10 @@ enum Commands {
         #[arg(long, value_name = "DURATION")]
         no_output_timeout: Option<String>,
 
+        /// Maximum number of test process restarts on timeout or crash
+        #[arg(long, value_name = "N")]
+        max_restarts: Option<usize>,
+
         /// Additional arguments to pass to the test command (use after --)
         #[arg(last = true, value_name = "TESTARGS")]
         testargs: Vec<String>,
@@ -420,6 +424,7 @@ fn main() {
             test_timeout,
             max_duration,
             no_output_timeout,
+            max_restarts,
             testfilters,
             testargs,
         } => {
@@ -482,6 +487,7 @@ fn main() {
                 test_timeout,
                 max_duration,
                 no_output_timeout,
+                max_restarts,
             };
             cmd.execute(&mut ui)
         }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -592,6 +592,7 @@ impl InquestMcpService {
                     all_output: false,
                     test_args: None,
                     cancellation_token: Some(cancel_token),
+                    max_restarts: None,
                 };
                 let executor = crate::test_executor::TestExecutor::new(&config);
 

--- a/src/test_executor.rs
+++ b/src/test_executor.rs
@@ -5,7 +5,7 @@
 //! fetching historical times, and persisting results after execution.
 
 use crate::config::{
-    TimeoutSetting, AUTO_MAX_DURATION_MINIMUM, AUTO_TIMEOUT_MULTIPLIER, MAX_TEST_TIMEOUT_RESTARTS,
+    TimeoutSetting, AUTO_MAX_DURATION_MINIMUM, AUTO_TIMEOUT_MULTIPLIER, MAX_TEST_RESTARTS,
 };
 use crate::error::Result;
 use crate::repository::{RunId, TestId, TestResult, TestRun};
@@ -121,6 +121,18 @@ impl std::fmt::Debug for CancellationToken {
     }
 }
 
+/// Reason the test runner exited and a restart is being considered.
+enum RestartReason {
+    /// A test exceeded its per-test timeout and the runner was killed.
+    Timeout { hung_test: String },
+    /// The runner exited with a non-success status (crash, panic, signal)
+    /// while one or more tests were still in progress.
+    Crash {
+        exit_status: std::process::ExitStatus,
+        blamed: HashSet<String>,
+    },
+}
+
 /// Configuration for test execution, independent of CLI argument parsing.
 pub struct TestExecutorConfig {
     /// Working directory for test execution.
@@ -131,6 +143,9 @@ pub struct TestExecutorConfig {
     pub test_args: Option<Vec<String>>,
     /// Optional cancellation token to stop execution.
     pub cancellation_token: Option<CancellationToken>,
+    /// Maximum number of test process restarts on timeout or crash.
+    /// `None` falls back to [`MAX_TEST_RESTARTS`].
+    pub max_restarts: Option<usize>,
 }
 
 impl TestExecutorConfig {
@@ -140,6 +155,10 @@ impl TestExecutorConfig {
         } else {
             subunit_stream::OutputFilter::FailuresOnly
         }
+    }
+
+    fn max_restarts(&self) -> usize {
+        self.max_restarts.unwrap_or(MAX_TEST_RESTARTS)
     }
 }
 
@@ -352,7 +371,9 @@ impl<'a> TestExecutor<'a> {
                 progress_bar.clone(),
             );
 
-            let watchdog = test_timeout_fn.as_ref().map(|_| TestWatchdog::new());
+            // Always construct the watchdog so crash attribution works even
+            // when no per-test timeout is configured.
+            let watchdog = Some(TestWatchdog::new());
             let watchdog_for_thread = watchdog.clone();
             let test_timeout_fn_clone = test_timeout_fn.cloned();
 
@@ -430,7 +451,8 @@ impl<'a> TestExecutor<'a> {
                 all_results.insert(id, result);
             }
 
-            match wait_result {
+            let max_restarts = self.config.max_restarts();
+            let restart_reason: Option<RestartReason> = match wait_result {
                 Err(TimeoutReason::TestTimeout(ref hung_test)) => {
                     tracing::warn!(
                         "test {} timed out, killing process and restarting",
@@ -439,52 +461,9 @@ impl<'a> TestExecutor<'a> {
                     let test_id = TestId::new(hung_test);
                     all_results.insert(test_id.clone(), timeout_error_result(test_id));
                     any_command_failed = true;
-
-                    if !test_cmd.supports_test_filtering() {
-                        tracing::warn!(
-                            "cannot restart: test command does not support \
-                             filtering by test ID ($IDOPTION/$IDFILE/$IDLIST)"
-                        );
-                        break;
-                    }
-
-                    let completed_from_watchdog = watchdog
-                        .as_ref()
-                        .map(|wd| wd.completed_tests())
-                        .unwrap_or_default();
-                    let completed_in_results: HashSet<&str> =
-                        all_results.keys().map(|id| id.as_str()).collect();
-                    let discovered_tests;
-                    let all_test_ids: &[TestId] = if let Some(ref ids) = remaining_tests {
-                        ids
-                    } else {
-                        discovered_tests = test_cmd.list_tests()?;
-                        &discovered_tests
-                    };
-                    let next_remaining = compute_remaining_tests(
-                        all_test_ids,
-                        &completed_from_watchdog,
-                        &completed_in_results,
-                        hung_test,
-                    );
-
-                    restarts += 1;
-                    if restarts >= MAX_TEST_TIMEOUT_RESTARTS || next_remaining.is_empty() {
-                        if restarts >= MAX_TEST_TIMEOUT_RESTARTS {
-                            tracing::error!(
-                                "exceeded maximum restart limit ({}), stopping",
-                                MAX_TEST_TIMEOUT_RESTARTS
-                            );
-                        }
-                        break;
-                    }
-
-                    tracing::warn!(
-                        "restarting test runner with {} remaining tests",
-                        next_remaining.len()
-                    );
-                    remaining_tests = Some(next_remaining);
-                    continue;
+                    Some(RestartReason::Timeout {
+                        hung_test: hung_test.clone(),
+                    })
                 }
                 Err(TimeoutReason::Cancelled) => {
                     tracing::info!("test run cancelled");
@@ -511,12 +490,129 @@ impl<'a> TestExecutor<'a> {
                     break;
                 }
                 Ok(status) => {
-                    if !status.success() {
-                        any_command_failed = true;
+                    if status.success() {
+                        break;
                     }
-                    break;
+                    any_command_failed = true;
+                    // Non-success exit. Only treat this as a crash worth
+                    // restarting when there were tests mid-flight — otherwise
+                    // it's an ordinary failing run that finished on its own.
+                    let in_progress = watchdog
+                        .as_ref()
+                        .map(|wd| wd.in_progress_tests())
+                        .unwrap_or_default();
+                    if in_progress.is_empty() {
+                        break;
+                    }
+                    Some(RestartReason::Crash {
+                        exit_status: status,
+                        blamed: in_progress,
+                    })
+                }
+            };
+
+            let Some(reason) = restart_reason else {
+                break;
+            };
+
+            if !test_cmd.supports_test_filtering() {
+                tracing::warn!(
+                    "cannot restart: test command does not support \
+                     filtering by test ID ($IDOPTION/$IDFILE/$IDLIST)"
+                );
+                break;
+            }
+
+            let completed_from_watchdog = watchdog
+                .as_ref()
+                .map(|wd| wd.completed_tests())
+                .unwrap_or_default();
+            let completed_in_results: HashSet<&str> =
+                all_results.keys().map(|id| id.as_str()).collect();
+            let discovered_tests;
+            let all_test_ids: &[TestId] = if let Some(ref ids) = remaining_tests {
+                ids
+            } else {
+                discovered_tests = test_cmd.list_tests()?;
+                &discovered_tests
+            };
+
+            // Genuine progress = at least one input test reached a terminal
+            // status. Measured BEFORE inserting crash error results so blamed
+            // tests don't inflate progress.
+            let made_progress = all_test_ids.iter().any(|id| {
+                completed_from_watchdog.contains(id.as_str())
+                    || completed_in_results.contains(id.as_str())
+            });
+
+            // Now blame the crashers (if any) so they are recorded as errors
+            // and excluded from the next iteration.
+            if let RestartReason::Crash {
+                ref exit_status,
+                ref blamed,
+            } = reason
+            {
+                for id in blamed {
+                    let test_id = TestId::new(id);
+                    all_results.insert(test_id.clone(), crash_error_result(test_id, exit_status));
                 }
             }
+
+            let hung_test = match &reason {
+                RestartReason::Timeout { hung_test } => hung_test.as_str(),
+                RestartReason::Crash { .. } => "",
+            };
+            let current_completed_in_results: HashSet<&str> =
+                all_results.keys().map(|id| id.as_str()).collect();
+            let next_remaining = compute_remaining_tests(
+                all_test_ids,
+                &completed_from_watchdog,
+                &current_completed_in_results,
+                hung_test,
+            );
+
+            if matches!(reason, RestartReason::Crash { .. }) && !made_progress {
+                tracing::error!(
+                    "test runner exited with {}, and no forward progress was made; \
+                     not restarting",
+                    match &reason {
+                        RestartReason::Crash { exit_status, .. } => format!("{}", exit_status),
+                        _ => unreachable!(),
+                    }
+                );
+                break;
+            }
+
+            restarts += 1;
+            if restarts >= max_restarts || next_remaining.is_empty() {
+                if restarts >= max_restarts {
+                    tracing::error!(
+                        "exceeded maximum restart limit ({}), stopping",
+                        max_restarts
+                    );
+                }
+                break;
+            }
+
+            match &reason {
+                RestartReason::Timeout { .. } => tracing::warn!(
+                    "restarting test runner with {} remaining tests",
+                    next_remaining.len()
+                ),
+                RestartReason::Crash {
+                    exit_status,
+                    blamed,
+                } => tracing::warn!(
+                    "test runner crashed ({}) while running {} test(s) ({}); \
+                     restarting with {} remaining tests",
+                    exit_status,
+                    blamed.len(),
+                    blamed.iter().cloned().collect::<Vec<_>>().join(", "),
+                    next_remaining.len()
+                ),
+            }
+            remaining_tests = Some(next_remaining);
+            continue;
         }
 
         progress_bar.finish_and_clear();
@@ -713,7 +809,9 @@ impl<'a> TestExecutor<'a> {
 
                 let channel_reader = crate::test_runner::ChannelReader::new(rx);
 
-                let worker_watchdog = test_timeout_fn.as_ref().map(|_| TestWatchdog::new());
+                // Always construct the watchdog so crash attribution works
+                // even when no per-test timeout is configured.
+                let worker_watchdog = Some(TestWatchdog::new());
                 let watchdog_for_thread = worker_watchdog.clone();
                 let watchdog_for_supervisor = worker_watchdog.clone();
                 let test_timeout_fn_clone = test_timeout_fn.cloned();
@@ -839,11 +937,12 @@ impl<'a> TestExecutor<'a> {
             }
 
             restarts += 1;
-            if restart_partitions.is_empty() || restarts >= MAX_TEST_TIMEOUT_RESTARTS {
-                if restarts >= MAX_TEST_TIMEOUT_RESTARTS && !restart_partitions.is_empty() {
+            let max_restarts = self.config.max_restarts();
+            if restart_partitions.is_empty() || restarts >= max_restarts {
+                if restarts >= max_restarts && !restart_partitions.is_empty() {
                     tracing::error!(
                         "exceeded maximum restart limit ({}), stopping",
-                        MAX_TEST_TIMEOUT_RESTARTS
+                        max_restarts
                     );
                 }
                 break;
@@ -1338,6 +1437,18 @@ fn timeout_error_result(test_id: TestId) -> TestResult {
     TestResult::error(test_id, "test timed out (killed after per-test timeout)")
 }
 
+/// Create an error result for a test that was in progress when the runner
+/// exited with a non-success status (crash, panic, signal).
+fn crash_error_result(test_id: TestId, exit_status: &std::process::ExitStatus) -> TestResult {
+    TestResult::error(
+        test_id,
+        format!(
+            "test runner exited while this test was running ({})",
+            exit_status
+        ),
+    )
+}
+
 /// Filter out tests that have already completed or timed out, returning the remaining tests.
 fn compute_remaining_tests(
     all_test_ids: &[TestId],
@@ -1574,6 +1685,70 @@ fn compute_restart_partitions(
             }
             Ok(status) if !status.success() => {
                 *any_failed = true;
+                // Non-success exit. Only treat as a crash worth restarting
+                // when there were tests mid-flight on this worker; otherwise
+                // it is an ordinary failing run that finished on its own.
+                let wd = worker_watchdogs.get(worker_id).and_then(|wd| wd.as_ref());
+                let in_progress = wd.map(|wd| wd.in_progress_tests()).unwrap_or_default();
+                if in_progress.is_empty() {
+                    continue;
+                }
+                let completed_from_watchdog = wd.map(|wd| wd.completed_tests()).unwrap_or_default();
+                let completed_in_results: HashSet<String> = all_results
+                    .keys()
+                    .map(|id| id.as_str().to_string())
+                    .collect();
+
+                let original_partition: &[TestId] = &pending_partitions
+                    .iter()
+                    .find(|(wid, _)| wid == worker_id)
+                    .expect("worker_id must exist in pending_partitions")
+                    .1;
+
+                // Genuine progress = at least one partition test completed
+                // (before blaming the crashers). Measure this BEFORE inserting
+                // crash error results so blamed tests don't inflate progress.
+                let made_progress = original_partition.iter().any(|id| {
+                    completed_from_watchdog.contains(id.as_str())
+                        || completed_in_results.contains(id.as_str())
+                });
+
+                // Blame the mid-flight tests.
+                for id in &in_progress {
+                    let test_id = TestId::new(id);
+                    all_results.insert(test_id.clone(), crash_error_result(test_id, status));
+                }
+
+                // Remaining = partition tests that are neither completed nor blamed.
+                let remaining: Vec<TestId> = original_partition
+                    .iter()
+                    .filter(|id| {
+                        !completed_from_watchdog.contains(id.as_str())
+                            && !completed_in_results.contains(id.as_str())
+                            && !in_progress.contains(id.as_str())
+                    })
+                    .cloned()
+                    .collect();
+
+                if !remaining.is_empty() && made_progress {
+                    tracing::warn!(
+                        "worker {} exited with {} while running {} test(s) ({}); \
+                         restarting with {} remaining tests",
+                        worker_id,
+                        status,
+                        in_progress.len(),
+                        in_progress.iter().cloned().collect::<Vec<_>>().join(", "),
+                        remaining.len()
+                    );
+                    restart_partitions.push((*worker_id, remaining));
+                } else if !remaining.is_empty() {
+                    tracing::error!(
+                        "worker {} exited with {} with no forward progress; \
+                         not restarting",
+                        worker_id,
+                        status
+                    );
+                }
             }
             Ok(_) => {}
         }
@@ -1692,6 +1867,7 @@ mod tests {
 #[cfg(test)]
 mod helper_tests {
     use super::*;
+    use crate::repository::TestStatus;
 
     #[test]
     fn test_truncate_test_name_no_truncation_needed() {
@@ -1782,6 +1958,177 @@ mod helper_tests {
         let (filled, empty) = get_progress_bar_colors(0.75);
         assert_eq!(filled, "red");
         assert_eq!(empty, "red");
+    }
+
+    #[cfg(unix)]
+    fn exit_status(code: i32) -> std::process::ExitStatus {
+        use std::os::unix::process::ExitStatusExt;
+        // The raw wait status encodes exit code in the high byte.
+        std::process::ExitStatus::from_raw(code << 8)
+    }
+
+    #[test]
+    fn test_compute_remaining_tests_filters_completed_and_hung() {
+        let all = vec![
+            TestId::new("a"),
+            TestId::new("b"),
+            TestId::new("c"),
+            TestId::new("d"),
+        ];
+        let completed_from_watchdog: HashSet<String> = ["a".to_string()].into_iter().collect();
+        let completed_in_results: HashSet<&str> = ["b"].into_iter().collect();
+        let remaining =
+            compute_remaining_tests(&all, &completed_from_watchdog, &completed_in_results, "c");
+        assert_eq!(remaining, vec![TestId::new("d")]);
+    }
+
+    #[test]
+    fn test_compute_remaining_tests_empty_hung_keeps_everything_not_completed() {
+        let all = vec![TestId::new("a"), TestId::new("b"), TestId::new("c")];
+        let completed_from_watchdog: HashSet<String> = ["a".to_string()].into_iter().collect();
+        let completed_in_results: HashSet<&str> = HashSet::new();
+        let remaining =
+            compute_remaining_tests(&all, &completed_from_watchdog, &completed_in_results, "");
+        assert_eq!(remaining, vec![TestId::new("b"), TestId::new("c")]);
+    }
+
+    #[test]
+    fn test_crash_error_result_is_error_status() {
+        #[cfg(unix)]
+        {
+            let status = exit_status(139);
+            let result = crash_error_result(TestId::new("mid.flight"), &status);
+            assert_eq!(result.test_id, TestId::new("mid.flight"));
+            assert_eq!(result.status, TestStatus::Error);
+            assert_eq!(
+                result.message.as_deref(),
+                Some("test runner exited while this test was running (exit status: 139)"),
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_compute_restart_partitions_crash_with_in_progress_blames_and_restarts() {
+        let watchdog = TestWatchdog::new();
+        watchdog.on_test_start("a", None);
+        watchdog.on_test_complete("a");
+        watchdog.on_test_start("b", None);
+        // "b" is left in progress — it's the test that crashed the runner.
+
+        let mut supervisor_results = HashMap::new();
+        supervisor_results.insert(0usize, Ok(exit_status(1)));
+
+        let mut worker_watchdogs = HashMap::new();
+        worker_watchdogs.insert(0usize, Some(watchdog));
+
+        let pending_partitions = vec![(
+            0usize,
+            vec![TestId::new("a"), TestId::new("b"), TestId::new("c")],
+        )];
+
+        let mut all_results = HashMap::new();
+        all_results.insert(TestId::new("a"), TestResult::success("a"));
+
+        let mut any_failed = false;
+        let restart = compute_restart_partitions(
+            &supervisor_results,
+            &worker_watchdogs,
+            &pending_partitions,
+            &mut all_results,
+            &mut any_failed,
+            std::time::Instant::now(),
+            None,
+        );
+
+        assert!(any_failed);
+        assert_eq!(restart, vec![(0usize, vec![TestId::new("c")])]);
+        // "b" was blamed with a crash error result.
+        let b_result = all_results
+            .get(&TestId::new("b"))
+            .expect("blamed test must be recorded");
+        assert_eq!(b_result.status, TestStatus::Error);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_compute_restart_partitions_crash_without_in_progress_does_not_restart() {
+        // Ordinary failing run: runner exited non-zero but no test was
+        // mid-flight. Should mark failure but not restart, and not inject a
+        // crash error for any test.
+        let watchdog = TestWatchdog::new();
+        watchdog.on_test_start("a", None);
+        watchdog.on_test_complete("a");
+        watchdog.on_test_start("b", None);
+        watchdog.on_test_complete("b");
+
+        let mut supervisor_results = HashMap::new();
+        supervisor_results.insert(0usize, Ok(exit_status(1)));
+
+        let mut worker_watchdogs = HashMap::new();
+        worker_watchdogs.insert(0usize, Some(watchdog));
+
+        let pending_partitions = vec![(0usize, vec![TestId::new("a"), TestId::new("b")])];
+
+        let mut all_results = HashMap::new();
+        all_results.insert(TestId::new("a"), TestResult::success("a"));
+        all_results.insert(
+            TestId::new("b"),
+            TestResult::failure("b", "assertion failed"),
+        );
+
+        let mut any_failed = false;
+        let restart = compute_restart_partitions(
+            &supervisor_results,
+            &worker_watchdogs,
+            &pending_partitions,
+            &mut all_results,
+            &mut any_failed,
+            std::time::Instant::now(),
+            None,
+        );
+
+        assert!(any_failed);
+        assert_eq!(restart, Vec::<(usize, Vec<TestId>)>::new());
+        // "b" keeps its original failure result, not overwritten by a crash error.
+        let b_result = all_results.get(&TestId::new("b")).unwrap();
+        assert_eq!(b_result.status, TestStatus::Failure);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_compute_restart_partitions_crash_with_no_forward_progress_does_not_restart() {
+        // First test crashes immediately — nothing completed, nothing to
+        // shrink the remaining set. Must not restart.
+        let watchdog = TestWatchdog::new();
+        watchdog.on_test_start("a", None);
+
+        let mut supervisor_results = HashMap::new();
+        supervisor_results.insert(0usize, Ok(exit_status(139)));
+
+        let mut worker_watchdogs = HashMap::new();
+        worker_watchdogs.insert(0usize, Some(watchdog));
+
+        let pending_partitions = vec![(0usize, vec![TestId::new("a"), TestId::new("b")])];
+
+        let mut all_results = HashMap::new();
+        let mut any_failed = false;
+        let restart = compute_restart_partitions(
+            &supervisor_results,
+            &worker_watchdogs,
+            &pending_partitions,
+            &mut all_results,
+            &mut any_failed,
+            std::time::Instant::now(),
+            None,
+        );
+
+        assert!(any_failed);
+        assert_eq!(restart, Vec::<(usize, Vec<TestId>)>::new());
+        // "a" was still blamed (recorded as crash error) even though we
+        // give up restarting — the user still sees which test killed the runner.
+        let a_result = all_results.get(&TestId::new("a")).unwrap();
+        assert_eq!(a_result.status, TestStatus::Error);
     }
 
     #[test]

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -71,8 +71,10 @@ pub struct TestWatchdog {
 
 #[derive(Default)]
 struct WatchdogState {
-    /// Currently in-progress tests with their deadlines.
-    in_progress: HashMap<String, Instant>,
+    /// Currently in-progress tests. The value holds an optional deadline;
+    /// `None` means the test is being tracked for crash attribution but has
+    /// no per-test timeout.
+    in_progress: HashMap<String, Option<Instant>>,
     /// Tests that reached a terminal status.
     completed: HashSet<String>,
 }
@@ -85,14 +87,13 @@ impl TestWatchdog {
         }
     }
 
-    /// Record that a test has started. If `timeout` is `Some`, a deadline is set.
+    /// Record that a test has started. If `timeout` is `Some`, a deadline is
+    /// set for timeout detection; otherwise the test is tracked without a
+    /// deadline so it can still be attributed on a crash.
     pub fn on_test_start(&self, test_id: &str, timeout: Option<Duration>) {
         let mut state = self.inner.lock().unwrap();
-        if let Some(t) = timeout {
-            state
-                .in_progress
-                .insert(test_id.to_string(), Instant::now() + t);
-        }
+        let deadline = timeout.map(|t| Instant::now() + t);
+        state.in_progress.insert(test_id.to_string(), deadline);
     }
 
     /// Record that a test has completed (any terminal status).
@@ -104,15 +105,16 @@ impl TestWatchdog {
 
     /// Check whether any in-progress test has exceeded its deadline.
     ///
-    /// Returns the test ID of the first overdue test, or `None`.
+    /// Returns the test ID of the first overdue test, or `None`. Tests
+    /// tracked without a deadline are ignored.
     pub fn check_timeout(&self) -> Option<String> {
         let state = self.inner.lock().unwrap();
         let now = Instant::now();
-        // Return the test with the earliest expired deadline
         state
             .in_progress
             .iter()
-            .filter(|(_, deadline)| now >= **deadline)
+            .filter_map(|(id, deadline)| deadline.map(|d| (id, d)))
+            .filter(|(_, deadline)| now >= *deadline)
             .min_by_key(|(_, deadline)| *deadline)
             .map(|(id, _)| id.clone())
     }
@@ -120,6 +122,18 @@ impl TestWatchdog {
     /// Snapshot of all test IDs that have completed so far.
     pub fn completed_tests(&self) -> HashSet<String> {
         self.inner.lock().unwrap().completed.clone()
+    }
+
+    /// Snapshot of all test IDs that are currently in progress (started but
+    /// not yet completed). Includes tests tracked without a deadline.
+    pub fn in_progress_tests(&self) -> HashSet<String> {
+        self.inner
+            .lock()
+            .unwrap()
+            .in_progress
+            .keys()
+            .cloned()
+            .collect()
     }
 }
 
@@ -244,6 +258,22 @@ mod tests {
         wd.on_test_start("hung", Some(Duration::ZERO));
         std::thread::sleep(Duration::from_millis(1));
         assert_eq!(wd.check_timeout(), Some("hung".to_string()));
+    }
+
+    #[test]
+    fn test_watchdog_in_progress_tests_tracks_without_deadline() {
+        let wd = TestWatchdog::new();
+        wd.on_test_start("a", None);
+        wd.on_test_start("b", Some(Duration::from_secs(60)));
+        assert_eq!(
+            wd.in_progress_tests(),
+            HashSet::from(["a".to_string(), "b".to_string()])
+        );
+        assert_eq!(wd.check_timeout(), None);
+
+        wd.on_test_complete("a");
+        assert_eq!(wd.in_progress_tests(), HashSet::from(["b".to_string()]));
+        assert_eq!(wd.completed_tests(), HashSet::from(["a".to_string()]));
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1246,6 +1246,7 @@ fn test_serial_run_with_cancellation() {
         all_output: false,
         test_args: None,
         cancellation_token: Some(token),
+        max_restarts: None,
     };
     let executor = TestExecutor::new(&exec_config);
 
@@ -1310,6 +1311,7 @@ fn test_isolated_run_with_cancellation() {
         all_output: false,
         test_args: None,
         cancellation_token: Some(token),
+        max_restarts: None,
     };
     let executor = TestExecutor::new(&exec_config);
 


### PR DESCRIPTION
Extend the existing timeout-restart mechanism to also handle crashes (panics, segfaults, or other non-success exits) while tests are still in progress. The watchdog now always tracks started tests regardless of whether a per-test timeout is configured, so in-flight tests can be attributed on a crash and recorded as errors.

Restart-on-crash only fires when forward progress was made — an ordinary failing run, where the runner exits non-zero because tests failed but every test ran to completion, is not treated as a crash.