### PR TITLE
Stream test listing stderr live during test discovery

### DIFF
--- a/src/testcommand.rs
+++ b/src/testcommand.rs
@@ -216,6 +216,24 @@ impl TestCommand {
     ///
     /// Times out after 5 minutes to avoid hanging indefinitely.
     pub fn list_tests(&self) -> Result<Vec<TestId>> {
+        self.list_tests_with_stderr(&mut std::io::stderr())
+    }
+
+    /// List all available tests, forwarding the child's stderr to `stderr_sink`
+    /// as it is produced.
+    ///
+    /// This lets callers surface build output (e.g. `cargo` compilation) live,
+    /// so the user isn't staring at a blank terminal while the test binary is
+    /// compiled. Passing `&mut std::io::sink()` preserves the old silent
+    /// behaviour.
+    ///
+    /// Times out after 5 minutes to avoid hanging indefinitely.
+    pub fn list_tests_with_stderr(
+        &self,
+        stderr_sink: &mut (dyn Write + Send),
+    ) -> Result<Vec<TestId>> {
+        use std::io::Read;
+        use std::sync::mpsc;
         use std::time::Duration;
 
         const LIST_TIMEOUT: Duration = Duration::from_secs(300);
@@ -234,44 +252,48 @@ impl TestCommand {
             })?;
 
         let stdout = child.stdout.take().expect("stdout was piped");
-        let stderr_handle = child.stderr.take().expect("stderr was piped");
+        let mut stderr_handle = child.stderr.take().expect("stderr was piped");
 
-        // Read stdout and stderr in background threads to avoid deadlock
+        // Read stdout in a background thread to avoid deadlock while the child
+        // writes to both stdout and stderr.
         let stdout_thread = std::thread::spawn(move || -> std::io::Result<Vec<u8>> {
             let mut buf = Vec::new();
             std::io::Read::read_to_end(&mut { stdout }, &mut buf)?;
             Ok(buf)
         });
-        let stderr_thread = std::thread::spawn(move || -> std::io::Result<Vec<u8>> {
-            let mut buf = Vec::new();
-            std::io::Read::read_to_end(&mut { stderr_handle }, &mut buf)?;
-            Ok(buf)
+
+        // Read stderr chunks in a background thread and deliver them on a
+        // channel. The main thread forwards each chunk to `stderr_sink` as it
+        // arrives, so build output surfaces live rather than only after exit.
+        let (stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>();
+        let stderr_reader = std::thread::spawn(move || -> std::io::Result<()> {
+            let mut buf = [0u8; 8192];
+            loop {
+                match stderr_handle.read(&mut buf) {
+                    Ok(0) => return Ok(()),
+                    Ok(n) => {
+                        if stderr_tx.send(buf[..n].to_vec()).is_err() {
+                            return Ok(());
+                        }
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
         });
 
-        // Wait with timeout
+        // Forward stderr chunks to the sink while polling the child for exit.
+        // Chunks are also retained so we can include them in an error message
+        // if the listing command fails.
+        let mut captured_stderr: Vec<u8> = Vec::new();
         let deadline = std::time::Instant::now() + LIST_TIMEOUT;
-        loop {
+        let exit_status = loop {
+            while let Ok(chunk) = stderr_rx.try_recv() {
+                let _ = stderr_sink.write_all(&chunk);
+                let _ = stderr_sink.flush();
+                captured_stderr.extend_from_slice(&chunk);
+            }
             match child.try_wait() {
-                Ok(Some(status)) => {
-                    let stdout_bytes = stdout_thread
-                        .join()
-                        .map_err(|_| Error::CommandExecution("stdout reader panicked".into()))?
-                        .map_err(Error::Io)?;
-
-                    if !status.success() {
-                        let stderr_bytes = stderr_thread
-                            .join()
-                            .map_err(|_| Error::CommandExecution("stderr reader panicked".into()))?
-                            .map_err(Error::Io)?;
-                        let stderr = String::from_utf8_lossy(&stderr_bytes);
-                        return Err(Error::CommandExecution(format!(
-                            "Test listing command failed with exit code: {}\nCommand: {}\nStderr:\n{}",
-                            status, cmd, stderr
-                        )));
-                    }
-
-                    return Self::parse_test_list(&stdout_bytes);
-                }
+                Ok(Some(status)) => break status,
                 Ok(None) => {
                     if std::time::Instant::now() >= deadline {
                         let _ = child.kill();
@@ -291,7 +313,30 @@ impl TestCommand {
                     )));
                 }
             }
+        };
+
+        // Drain any stderr written between the last try_recv and child exit.
+        let _ = stderr_reader.join();
+        while let Ok(chunk) = stderr_rx.try_recv() {
+            let _ = stderr_sink.write_all(&chunk);
+            let _ = stderr_sink.flush();
+            captured_stderr.extend_from_slice(&chunk);
         }
+
+        let stdout_bytes = stdout_thread
+            .join()
+            .map_err(|_| Error::CommandExecution("stdout reader panicked".into()))?
+            .map_err(Error::Io)?;
+
+        if !exit_status.success() {
+            let stderr = String::from_utf8_lossy(&captured_stderr);
+            return Err(Error::CommandExecution(format!(
+                "Test listing command failed with exit code: {}\nCommand: {}\nStderr:\n{}",
+                exit_status, cmd, stderr
+            )));
+        }
+
+        Self::parse_test_list(&stdout_bytes)
     }
 
     fn parse_test_list(output: &[u8]) -> Result<Vec<TestId>> {

--- a/tests/testcommand_tests.rs
+++ b/tests/testcommand_tests.rs
@@ -57,3 +57,105 @@ fn test_list_tests_parses_subunit_enumeration() {
     assert_eq!(test_ids[0].to_string(), "test.example.test_one");
     assert_eq!(test_ids[1].to_string(), "test.example.test_two");
 }
+
+#[test]
+fn test_list_tests_forwards_stderr_live() {
+    // Verify that list_tests_with_stderr forwards child-process stderr output
+    // to the provided sink as it is produced. This is what surfaces build
+    // output (e.g. `cargo` compilation) to the user before tests start.
+    let temp = TempDir::new().unwrap();
+    let base_path = temp.path();
+
+    // Subunit v2 bytes for a single enumeration event on test.example.test_one,
+    // so the listing call still succeeds.
+    let subunit_data: &[u8] = &[
+        0xb3, 0x29, 0x01, 0x1e, 0x15, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x65, 0x78, 0x61, 0x6d, 0x70,
+        0x6c, 0x65, 0x2e, 0x74, 0x65, 0x73, 0x74, 0x5f, 0x6f, 0x6e, 0x65, 0x63, 0xe2, 0xa6, 0x82,
+    ];
+
+    // Script writes to stderr, sleeps briefly, then emits subunit on stdout.
+    let script_path = base_path.join("test_script.sh");
+    let mut script = std::fs::File::create(&script_path).unwrap();
+    writeln!(script, "#!/bin/bash").unwrap();
+    writeln!(script, "echo 'BUILD LINE 1' >&2").unwrap();
+    writeln!(script, "echo 'BUILD LINE 2' >&2").unwrap();
+    write!(script, "printf '").unwrap();
+    for byte in subunit_data {
+        write!(script, "\\x{:02x}", byte).unwrap();
+    }
+    writeln!(script, "'").unwrap();
+    drop(script);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+    }
+
+    let config_path = base_path.join(".testr.conf");
+    let mut config = std::fs::File::create(&config_path).unwrap();
+    writeln!(
+        config,
+        "[DEFAULT]\ntest_command=bash test_script.sh\ntest_list_option=--list"
+    )
+    .unwrap();
+
+    let test_command = TestCommand::from_directory(base_path).unwrap();
+    let mut stderr_sink: Vec<u8> = Vec::new();
+    let test_ids = test_command
+        .list_tests_with_stderr(&mut stderr_sink)
+        .unwrap();
+
+    assert_eq!(test_ids.len(), 1);
+    let forwarded = String::from_utf8(stderr_sink).unwrap();
+    assert_eq!(forwarded, "BUILD LINE 1\nBUILD LINE 2\n");
+}
+
+#[test]
+fn test_list_tests_reports_stderr_on_failure() {
+    // When the listing command fails, its stderr should still be included in
+    // the error message (not swallowed by the live-forwarding tee).
+    let temp = TempDir::new().unwrap();
+    let base_path = temp.path();
+
+    let script_path = base_path.join("test_script.sh");
+    let mut script = std::fs::File::create(&script_path).unwrap();
+    writeln!(script, "#!/bin/bash").unwrap();
+    writeln!(script, "echo 'compile error: boom' >&2").unwrap();
+    writeln!(script, "exit 1").unwrap();
+    drop(script);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+    }
+
+    let config_path = base_path.join(".testr.conf");
+    let mut config = std::fs::File::create(&config_path).unwrap();
+    writeln!(
+        config,
+        "[DEFAULT]\ntest_command=bash test_script.sh\ntest_list_option=--list"
+    )
+    .unwrap();
+
+    let test_command = TestCommand::from_directory(base_path).unwrap();
+    let mut stderr_sink: Vec<u8> = Vec::new();
+    let err = test_command
+        .list_tests_with_stderr(&mut stderr_sink)
+        .unwrap_err();
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("compile error: boom"),
+        "error should include captured stderr, got: {msg}"
+    );
+    // And it should also have been forwarded live.
+    assert_eq!(
+        String::from_utf8(stderr_sink).unwrap(),
+        "compile error: boom\n"
+    );
+}


### PR DESCRIPTION
When listing tests (e.g. `cargo subunit --list`), the child's stderr was fully buffered until exit. For Rust projects this meant the user saw a blank terminal for the entire cargo build before tests started.

Forward the listing command's stderr to std::io::stderr() as it arrives, while still capturing it so failures can include it in the error message.

Fixes #65