### PR TITLE
Default to `run --auto` when no subcommand is given

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ struct Cli {
     directory: Option<String>,
 
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 #[derive(Subcommand)]
@@ -307,7 +307,27 @@ fn main() {
 
     let mut ui = CliUI;
 
-    let result = match cli.command {
+    let command = cli.command.unwrap_or(Commands::Run {
+        failing: false,
+        force_init: false,
+        auto: true,
+        partial: false,
+        load_list: None,
+        parallel: None,
+        until_failure: false,
+        max_iterations: None,
+        isolated: false,
+        subunit: false,
+        all_output: false,
+        testfilters: Vec::new(),
+        test_timeout: None,
+        max_duration: None,
+        no_output_timeout: None,
+        max_restarts: None,
+        testargs: Vec::new(),
+    });
+
+    let result = match command {
         Commands::Auto => {
             let cmd = AutoCommand::new(cli.directory);
             cmd.execute(&mut ui)

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,0 +1,63 @@
+//! Tests for top-level CLI behavior (subprocess-based).
+
+use std::process::Command;
+use tempfile::TempDir;
+
+fn inq_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_inq")
+}
+
+#[test]
+fn no_subcommand_runs_with_auto() {
+    // With no subcommand, `inq` should behave like `inq run --auto`. In an empty
+    // directory with no recognizable project, that means the auto-detection
+    // error path fires (rather than clap's "missing subcommand" usage error or
+    // the plain `inq run` "repository not found" error).
+    let temp = TempDir::new().unwrap();
+
+    let no_arg = Command::new(inq_bin())
+        .arg("-C")
+        .arg(temp.path())
+        .output()
+        .expect("run inq");
+
+    let auto_arg = Command::new(inq_bin())
+        .arg("-C")
+        .arg(temp.path())
+        .arg("run")
+        .arg("--auto")
+        .output()
+        .expect("run inq run --auto");
+
+    assert_eq!(no_arg.status.code(), auto_arg.status.code());
+    assert_eq!(no_arg.stdout, auto_arg.stdout);
+    assert_eq!(no_arg.stderr, auto_arg.stderr);
+
+    let stderr = String::from_utf8_lossy(&no_arg.stderr);
+    assert!(
+        stderr.contains("Could not detect project type"),
+        "expected auto-detect failure, got stderr: {stderr}"
+    );
+}
+
+#[test]
+fn no_subcommand_differs_from_plain_run() {
+    // Sanity check: `inq` (no args) must NOT be equivalent to `inq run` — it
+    // should imply --auto. With no inquest.toml present, plain `inq run` errors
+    // out about a missing repository instead of attempting auto-detection.
+    let temp = TempDir::new().unwrap();
+
+    let no_arg = Command::new(inq_bin())
+        .arg("-C")
+        .arg(temp.path())
+        .output()
+        .expect("run inq");
+    let plain_run = Command::new(inq_bin())
+        .arg("-C")
+        .arg(temp.path())
+        .arg("run")
+        .output()
+        .expect("run inq run");
+
+    assert_ne!(no_arg.stderr, plain_run.stderr);
+}


### PR DESCRIPTION
Running `inq` with no arguments now behaves like `inq run --auto`, making the common case (run my tests) a single word.