### PR TITLE
Add `--tag` flag to `inq run`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,10 @@ CHANGES
   (config file + CLI overrides + defaults) with each value annotated by
   its source. Closes #71. (Jelmer Vernooĳ)
 
+* Add ``--tag`` to ``inq run`` for filtering the post-run summary counts
+  by result tag. Repeatable; prefix with ``!`` to exclude. Overrides
+  ``filter_tags`` from the config. Closes #70. (Jelmer Vernooĳ)
+
 * Add ``inq flaky`` and the ``inq_flaky`` MCP tool, ranking tests by
   pass↔fail transitions across recorded runs so chronically broken tests
   rank below genuinely flapping ones. (Jelmer Vernooĳ)

--- a/doc/src/hiding-tests.md
+++ b/doc/src/hiding-tests.md
@@ -18,6 +18,6 @@ negation prefixed with `!` (results carrying that tag are skipped).
 The same selection can be supplied on the command line via `--tag`, which can
 be repeated and overrides `filter_tags` from the config:
 
-```
+```sh
 inq run --tag worker-0 --tag '!slow'
 ```

--- a/doc/src/hiding-tests.md
+++ b/doc/src/hiding-tests.md
@@ -10,6 +10,14 @@ count depending on the number of worker threads that were used. Scheduling such
 implicitly when preparing (or finishing with) a test environment to run other
 tests in.
 
-inq can ignore such tests if they are tagged, using the filter_tags
-configuration option. Tests tagged with any tag in that (space separated) list
-will only be included in counts and reports if the test failed (or errored).
+inq can restrict counts and reports to a particular tag selection using the
+`filter_tags` configuration option (a space-separated list). Each entry is
+either a positive tag (only results carrying that tag are counted) or a
+negation prefixed with `!` (results carrying that tag are skipped).
+
+The same selection can be supplied on the command line via `--tag`, which can
+be repeated and overrides `filter_tags` from the config:
+
+```
+inq run --tag worker-0 --tag '!slow'
+```

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -62,6 +62,11 @@ pub struct RunCommand {
     pub all_output: bool,
     /// Test patterns to filter
     pub test_filters: Option<Vec<String>>,
+    /// Tag filters used when summarising counts. `None` means fall back to
+    /// the `filter_tags` value in the config; `Some(_)` overrides it (an
+    /// empty `Vec` clears the filter entirely). Each entry may be a positive
+    /// tag (e.g. `worker-0`) or an exclusion (`!slow`).
+    pub filter_tags: Option<Vec<String>>,
     /// `-s`/`--starting-with` prefixes (possibly abbreviated; expanded
     /// against the discovered test list before matching).
     pub starting_with: Option<Vec<String>>,
@@ -159,6 +164,7 @@ impl RunCommand {
         repo: &mut dyn crate::repository::Repository,
         output: crate::test_executor::RunOutput,
         historical_times: &std::collections::HashMap<crate::repository::TestId, Duration>,
+        filter_tags: &[String],
     ) -> Result<CliRunOutput> {
         let (exit_code, run_id) = crate::commands::utils::persist_and_display_run(
             ui,
@@ -166,6 +172,7 @@ impl RunCommand {
             output,
             self.partial,
             historical_times,
+            filter_tags,
         )?;
         Ok(CliRunOutput {
             exit_code,
@@ -189,6 +196,13 @@ impl RunCommand {
             open_or_init_repository(self.base_path.as_deref(), self.force_init || self.auto, ui)?;
 
         let test_cmd = TestCommand::from_directory(base)?;
+
+        // CLI overrides config; fall back to whatever `filter_tags` is set to
+        // in the config file when no CLI flag was given.
+        let filter_tags: Vec<String> = match &self.filter_tags {
+            Some(tags) => tags.clone(),
+            None => test_cmd.config().parsed_filter_tags(),
+        };
 
         let (test_timeout, max_duration, no_output_timeout) = test_executor::resolve_timeouts(
             &self.test_timeout,
@@ -349,7 +363,7 @@ impl RunCommand {
             self.publish_run_id(&run_id);
             let output =
                 executor.run_subunit(ui, &test_cmd, test_ids.as_deref(), run_id, writer)?;
-            return self.persist(ui, repo.as_mut(), output, &historical_times);
+            return self.persist(ui, repo.as_mut(), output, &historical_times, &filter_tags);
         }
 
         let concurrency = if let Some(explicit_concurrency) = self.concurrency {
@@ -418,7 +432,8 @@ impl RunCommand {
                         max_duration_value,
                         iter_run_id,
                     )?;
-                    let result = self.persist(ui, repo.as_mut(), output, &historical_times)?;
+                    let result =
+                        self.persist(ui, repo.as_mut(), output, &historical_times, &filter_tags)?;
 
                     if result.exit_code != 0 {
                         ui.output(&format!("\nTests failed on iteration {}", iteration))?;
@@ -436,7 +451,7 @@ impl RunCommand {
                     max_duration_value,
                     run_id,
                 )?;
-                self.persist(ui, repo.as_mut(), output, &historical_times)
+                self.persist(ui, repo.as_mut(), output, &historical_times, &filter_tags)
             }
         } else if self.until_failure {
             let mut iteration = 1;
@@ -483,7 +498,8 @@ impl RunCommand {
                     )?
                 };
 
-                let result = self.persist(ui, repo.as_mut(), output, &historical_times)?;
+                let result =
+                    self.persist(ui, repo.as_mut(), output, &historical_times, &filter_tags)?;
 
                 if result.exit_code != 0 {
                     ui.output(&format!("\nTests failed on iteration {}", iteration))?;
@@ -507,7 +523,7 @@ impl RunCommand {
                 &historical_times,
                 || repo.begin_test_run_raw().map(|(_, w)| w),
             )?;
-            self.persist(ui, repo.as_mut(), output, &historical_times)
+            self.persist(ui, repo.as_mut(), output, &historical_times, &filter_tags)
         } else {
             let (run_id, writer) = repo.begin_test_run_raw()?;
             self.publish_run_id(&run_id);
@@ -522,7 +538,7 @@ impl RunCommand {
                 writer,
                 &historical_times,
             )?;
-            self.persist(ui, repo.as_mut(), output, &historical_times)
+            self.persist(ui, repo.as_mut(), output, &historical_times, &filter_tags)
         }
     }
 }

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -189,13 +189,32 @@ pub fn update_repository_failing_tests(
     Ok(())
 }
 
-/// Display a test run summary
-pub fn display_test_summary(ui: &mut dyn UI, run_id: &RunId, test_run: &TestRun) -> Result<()> {
-    let total = test_run.total_tests();
-    let failures = test_run.count_failures();
-    let successes = test_run.count_successes();
+/// Display a test run summary, optionally restricting the counts to a tag
+/// filter.
+pub fn display_test_summary(
+    ui: &mut dyn UI,
+    run_id: &RunId,
+    test_run: &TestRun,
+    filter_tags: &[String],
+) -> Result<()> {
+    let (total, successes, failures) = if filter_tags.is_empty() {
+        (
+            test_run.total_tests(),
+            test_run.count_successes(),
+            test_run.count_failures(),
+        )
+    } else {
+        (
+            test_run.total_tests_filtered(filter_tags),
+            test_run.count_successes_filtered(filter_tags),
+            test_run.count_failures_filtered(filter_tags),
+        )
+    };
 
     ui.output(&format!("\nTest run {}:", run_id))?;
+    if !filter_tags.is_empty() {
+        ui.output(&format!("  Tag filter: {}", filter_tags.join(", ")))?;
+    }
     ui.output(&format!("  Total:   {}", total))?;
     ui.output(&format!("  Passed:  {}", successes))?;
     ui.output(&format!("  Failed:  {}", failures))?;
@@ -278,6 +297,7 @@ pub fn persist_and_display_run(
     output: crate::test_executor::RunOutput,
     partial: bool,
     historical_times: &std::collections::HashMap<crate::repository::TestId, std::time::Duration>,
+    filter_tags: &[String],
 ) -> Result<(i32, RunId)> {
     let exit_code = output.exit_code();
     let crate::test_executor::RunOutput {
@@ -306,7 +326,7 @@ pub fn persist_and_display_run(
         Some(exit_code),
     )?;
 
-    display_test_summary(ui, &run_id, &combined_run)?;
+    display_test_summary(ui, &run_id, &combined_run, filter_tags)?;
     warn_slow_tests(ui, &combined_run, historical_times)?;
 
     Ok((exit_code, run_id))
@@ -566,12 +586,58 @@ mod tests {
         let mut ui = crate::ui::test_ui::TestUI::new();
         let historical = std::collections::HashMap::new();
         let (exit_code, run_id) =
-            persist_and_display_run(&mut ui, repo.as_mut(), output, false, &historical).unwrap();
+            persist_and_display_run(&mut ui, repo.as_mut(), output, false, &historical, &[])
+                .unwrap();
 
         assert_eq!(exit_code, 0);
         assert_eq!(run_id.as_str(), "1");
         let ui_text = ui.output.join("\n");
         assert!(ui_text.contains("Passed:  1"), "got: {}", ui_text);
+    }
+
+    #[test]
+    fn test_display_test_summary_with_filter_tags() {
+        let mut run = TestRun::new(RunId::new("7"));
+        run.add_result(crate::repository::TestResult::success("test1").with_tag("worker-0"));
+        run.add_result(crate::repository::TestResult::success("test2").with_tag("worker-1"));
+        run.add_result(
+            crate::repository::TestResult::failure("test3", "boom").with_tag("worker-0"),
+        );
+
+        let mut ui = crate::ui::test_ui::TestUI::new();
+        display_test_summary(&mut ui, &RunId::new("7"), &run, &["worker-0".to_string()]).unwrap();
+
+        assert_eq!(
+            ui.output,
+            vec![
+                "\nTest run 7:".to_string(),
+                "  Tag filter: worker-0".to_string(),
+                "  Total:   2".to_string(),
+                "  Passed:  1".to_string(),
+                "  Failed:  1".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_display_test_summary_with_excluded_tag() {
+        let mut run = TestRun::new(RunId::new("8"));
+        run.add_result(crate::repository::TestResult::success("fast1"));
+        run.add_result(crate::repository::TestResult::success("slow1").with_tag("slow"));
+
+        let mut ui = crate::ui::test_ui::TestUI::new();
+        display_test_summary(&mut ui, &RunId::new("8"), &run, &["!slow".to_string()]).unwrap();
+
+        assert_eq!(
+            ui.output,
+            vec![
+                "\nTest run 8:".to_string(),
+                "  Tag filter: !slow".to_string(),
+                "  Total:   1".to_string(),
+                "  Passed:  1".to_string(),
+                "  Failed:  0".to_string(),
+            ]
+        );
     }
 
     #[test]
@@ -601,7 +667,8 @@ mod tests {
         let mut ui = crate::ui::test_ui::TestUI::new();
         let historical = std::collections::HashMap::new();
         let (exit_code, run_id) =
-            persist_and_display_run(&mut ui, repo.as_mut(), output, false, &historical).unwrap();
+            persist_and_display_run(&mut ui, repo.as_mut(), output, false, &historical, &[])
+                .unwrap();
 
         assert_eq!(exit_code, 1);
         assert_eq!(run_id.as_str(), "0");

--- a/src/config.rs
+++ b/src/config.rs
@@ -344,6 +344,17 @@ impl TestrConfig {
         }
     }
 
+    /// Parse the configured `filter_tags` into a list of tag entries.
+    ///
+    /// Tags are space-separated. A leading `!` marks an exclusion; otherwise
+    /// the entry is an inclusion.
+    pub fn parsed_filter_tags(&self) -> Vec<String> {
+        match &self.filter_tags {
+            None => Vec::new(),
+            Some(s) => s.split_whitespace().map(|t| t.to_string()).collect(),
+        }
+    }
+
     /// Parse the no_output_timeout config value into a Duration.
     pub fn parsed_no_output_timeout(&self) -> Result<Option<Duration>> {
         match &self.no_output_timeout {
@@ -781,5 +792,24 @@ test_command = "python -m test"
             TimeoutSetting::Disabled
         );
         assert_eq!(config.parsed_no_output_timeout().unwrap(), None);
+    }
+
+    #[test]
+    fn test_parsed_filter_tags_unset() {
+        let config = TestrConfig::parse_toml(r#"test_command = "echo""#).unwrap();
+        assert_eq!(config.parsed_filter_tags(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_parsed_filter_tags_space_separated() {
+        let config_str = r#"
+test_command = "echo"
+filter_tags = "worker-0  !slow"
+"#;
+        let config = TestrConfig::parse_toml(config_str).unwrap();
+        assert_eq!(
+            config.parsed_filter_tags(),
+            vec!["worker-0".to_string(), "!slow".to_string()]
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,6 +275,13 @@ enum Commands {
         #[arg(value_name = "TESTFILTER")]
         testfilters: Vec<String>,
 
+        /// Restrict the post-run summary counts to results carrying the given
+        /// tag. Repeat to allow several tags. Prefix with `!` to exclude
+        /// results carrying the tag (e.g. `--tag worker-0 --tag '!slow'`).
+        /// Overrides `filter_tags` from the config file.
+        #[arg(long = "tag", value_name = "TAG")]
+        filter_tags: Vec<String>,
+
         /// Run only tests whose ID starts with this prefix. Dotted segments
         /// may be abbreviated to single letters when the expansion against
         /// the discovered test list is unique (e.g. "bt.test_foo" expanding
@@ -371,6 +378,7 @@ fn main() {
         subunit: false,
         all_output: false,
         testfilters: Vec::new(),
+        filter_tags: Vec::new(),
         starting_with: Vec::new(),
         test_timeout: None,
         max_duration: None,
@@ -577,6 +585,7 @@ fn main() {
             max_restarts,
             order,
             testfilters,
+            filter_tags,
             starting_with,
             testargs,
         } => {
@@ -640,6 +649,11 @@ fn main() {
                     None
                 } else {
                     Some(testfilters)
+                },
+                filter_tags: if filter_tags.is_empty() {
+                    None
+                } else {
+                    Some(filter_tags)
                 },
                 starting_with: if starting_with.is_empty() {
                     None

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1693,6 +1693,7 @@ impl InquestMcpService {
                                     output,
                                     partial,
                                     &historical_times,
+                                    &[],
                                 ) {
                                     tracing::error!(
                                         "Failed to persist background run results: {}",

--- a/src/repository/test_run.rs
+++ b/src/repository/test_run.rs
@@ -414,13 +414,39 @@ impl TestRun {
             .map(|first| durations.fold(first, |acc, d| acc + d))
     }
 
-    /// Check if a result matches the given tag filter
+    /// Check if a result matches the given tag filter.
+    ///
+    /// Each entry in `filter_tags` is either a positive tag (the result must
+    /// carry one of them) or an exclusion (`!tag`, the result must not carry
+    /// that tag). When no positive entries are supplied, any result that
+    /// avoids all exclusions matches.
     fn matches_filter(result: &TestResult, filter_tags: &[String]) -> bool {
         if filter_tags.is_empty() {
             return true;
         }
-        // Result matches if it has any of the filter tags
-        result.tags.iter().any(|tag| filter_tags.contains(tag))
+
+        let (excludes, includes): (Vec<&str>, Vec<&str>) = filter_tags
+            .iter()
+            .map(|t| t.as_str())
+            .partition(|t| t.starts_with('!'));
+        let excludes: Vec<&str> = excludes.iter().map(|t| &t[1..]).collect();
+
+        if result
+            .tags
+            .iter()
+            .any(|tag| excludes.contains(&tag.as_str()))
+        {
+            return false;
+        }
+
+        if includes.is_empty() {
+            return true;
+        }
+
+        result
+            .tags
+            .iter()
+            .any(|tag| includes.contains(&tag.as_str()))
     }
 
     /// Count failures matching the given tags
@@ -661,6 +687,47 @@ mod tests {
 
         // Filter should match if result has ANY of the filter tags
         let filter = vec!["slow".to_string()];
+        assert_eq!(run.total_tests_filtered(&filter), 1);
+    }
+
+    #[test]
+    fn test_filtered_counts_exclude_tag() {
+        let mut run = TestRun::new(RunId::new("0"));
+
+        run.add_result(TestResult::success("test1").with_tag("slow"));
+        run.add_result(TestResult::success("test2").with_tag("fast"));
+        run.add_result(TestResult::failure("test3", "Failed").with_tag("slow"));
+
+        let filter = vec!["!slow".to_string()];
+        assert_eq!(run.total_tests_filtered(&filter), 1);
+        assert_eq!(run.count_successes_filtered(&filter), 1);
+        assert_eq!(run.count_failures_filtered(&filter), 0);
+    }
+
+    #[test]
+    fn test_filtered_counts_include_and_exclude() {
+        let mut run = TestRun::new(RunId::new("0"));
+
+        run.add_result(
+            TestResult::success("test1")
+                .with_tag("worker-0")
+                .with_tag("slow"),
+        );
+        run.add_result(TestResult::success("test2").with_tag("worker-0"));
+        run.add_result(TestResult::success("test3").with_tag("worker-1"));
+
+        let filter = vec!["worker-0".to_string(), "!slow".to_string()];
+        assert_eq!(run.total_tests_filtered(&filter), 1);
+    }
+
+    #[test]
+    fn test_filtered_counts_exclude_only_untagged_passes() {
+        let mut run = TestRun::new(RunId::new("0"));
+
+        run.add_result(TestResult::success("test1"));
+        run.add_result(TestResult::success("test2").with_tag("slow"));
+
+        let filter = vec!["!slow".to_string()];
         assert_eq!(run.total_tests_filtered(&filter), 1);
     }
 }


### PR DESCRIPTION
Overrides the `filter_tags` config option, scoping post-run summary counts to results carrying (or, with a `!` prefix, lacking) the given tags.

Fixes #70