### PR TITLE
Exclude never-failing tests from `inq flaky`

### DIFF
--- a/src/commands/flaky.rs
+++ b/src/commands/flaky.rs
@@ -154,19 +154,39 @@ mod tests {
         );
 
         let stats = repo.get_flakiness(5).unwrap();
-        assert_eq!(stats.len(), 3);
+        // stable_test never failed, so it must not appear in the flakiness report.
+        assert_eq!(stats.len(), 2);
+        assert!(!stats.iter().any(|s| s.test_id.as_str() == "stable_test"));
         assert_eq!(stats[0].test_id.as_str(), "flapping_test");
         assert_eq!(stats[0].transitions, 5);
         assert_eq!(stats[0].runs, 6);
         assert_eq!(stats[0].failures, 3);
         // Broken test should rank below flapping (more failures, no transitions).
-        assert!(stats.iter().any(|s| s.test_id.as_str() == "broken_test"));
         let broken = stats
             .iter()
             .find(|s| s.test_id.as_str() == "broken_test")
             .unwrap();
         assert_eq!(broken.transitions, 0);
         assert_eq!(broken.failures, 6);
+    }
+
+    #[test]
+    fn never_failed_tests_are_excluded() {
+        let temp = TempDir::new().unwrap();
+        let factory = InquestRepositoryFactory;
+        let mut repo = factory.initialise(temp.path()).unwrap();
+
+        use TestStatus::Success;
+        build_history(
+            repo.as_mut(),
+            &[(
+                "always_passes",
+                &[Success, Success, Success, Success, Success],
+            )],
+        );
+
+        let stats = repo.get_flakiness(2).unwrap();
+        assert!(stats.is_empty());
     }
 
     #[test]

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -235,6 +235,11 @@ pub fn summarise_flakiness(
                 return None;
             }
             let failures = statuses.iter().filter(|&&f| f).count() as u32;
+            // Tests that have never failed aren't flaky by any definition —
+            // exclude them so the report focuses on tests that actually flap.
+            if failures == 0 {
+                return None;
+            }
             let transitions = statuses.windows(2).filter(|w| w[0] != w[1]).count() as u32;
             let denom = runs.saturating_sub(1).max(1) as f64;
             let flakiness_score = transitions as f64 / denom;


### PR DESCRIPTION
A test that has only ever passed is not flaky by any definition, so filter it out of the flakiness report rather than listing it next to chronically broken tests with 0 transitions.