### PR TITLE
Add support for named profiles in inquest.toml

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,19 @@ UNRELEASED
 CHANGES
 -------
 
+* Add support for named **profiles** in ``inquest.toml``. Top-level
+  fields form the implicit base layer; ``[profiles.<name>]`` tables
+  declare overlayable variants. Select one with ``inq --profile NAME``,
+  the ``INQ_PROFILE`` environment variable, or the optional
+  ``default_profile`` config field. ``Some("")`` in a profile clears the
+  base value rather than inheriting it. The active profile is persisted
+  in run metadata so ``inq info`` can show which profile produced a run;
+  ``inq config`` honours ``--profile`` and adds ``[profile:<name>]``
+  source annotations, plus a new ``--list-profiles`` flag. Existing flat
+  configs continue to load unchanged. Profiles are TOML-only;
+  ``.testr.conf`` configs do not support them. Closes #99.
+  (Jelmer Vernooĳ)
+
 * Add ``inq prune`` for dropping older test runs from the repository.
   Selection modes: ``--keep <N>`` keeps the N most recent runs,
   ``--older-than <DURATION>`` drops runs older than the given age

--- a/doc/src/configuration.md
+++ b/doc/src/configuration.md
@@ -58,3 +58,55 @@ test_list_option = "--list"
 Durations are specified as a number with an optional unit suffix:
 `s` (seconds, default), `m` (minutes), `h` (hours). Fractional values
 like `"1.5m"` are supported.
+
+## Profiles
+
+A TOML config may declare named **profiles** under `[profiles.<name>]` to
+switch between alternative sets of values. Top-level fields form the
+implicit *base* layer; a selected profile overlays its set fields on top
+of the base, leaving unset fields alone.
+
+```toml
+test_command = "python -m subunit.run discover . $LISTOPT $IDOPTION"
+test_id_option = "--load-list $IDFILE"
+test_list_option = "--list"
+test_timeout = "1m"
+
+# Optional: applied when no --profile / INQ_PROFILE is given.
+default_profile = "dev"
+
+[profiles.ci]
+test_timeout = "5m"
+test_order = "alphabetical"
+max_duration = "30m"
+
+[profiles.nightly]
+test_timeout = "10m"
+filter_tags = ""                 # explicit empty clears base value
+test_order = "frequent-failing-first"
+```
+
+Selection precedence (highest first):
+
+1. `--profile NAME` on the command line
+2. `INQ_PROFILE` environment variable
+3. `default_profile` from the config file
+4. base only (no overlay)
+
+The reserved name `default` always means "base only" and may not appear
+as a `[profiles.default]` table. Profile names must be non-empty and
+must not contain `.`, `/`, or whitespace, or start with `_`.
+
+A profile that sets a field to the empty string (e.g.
+`filter_tags = ""`) **clears** the base value rather than inheriting it
+— `Some("")` is treated as a real override, not as "unset".
+
+`inq config --list-profiles` prints the defined profile names; `inq
+config --profile NAME` prints the resolved view through that profile,
+annotating each value with `[profile:NAME]` when it came from the
+overlay and `[config]` when it came from the base layer. The active
+profile name is also recorded in run metadata, so `inq info` can show
+which profile produced a given run.
+
+Profiles are not supported in the legacy `.testr.conf` (INI) format;
+use `inq upgrade` to migrate to TOML first.

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,7 +1,7 @@
 //! Show the resolved effective configuration
 
 use crate::commands::Command;
-use crate::config::{TestrConfig, TimeoutSetting};
+use crate::config::{ConfigFile, TestrConfig, TimeoutSetting};
 use crate::error::Result;
 use crate::ordering::TestOrder;
 use crate::ui::UI;
@@ -9,19 +9,21 @@ use std::path::Path;
 use std::time::Duration;
 
 /// Origin of a resolved configuration value.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum Source {
     Cli,
+    Profile(String),
     Config,
     Default,
 }
 
 impl Source {
-    fn label(self) -> &'static str {
+    fn label(&self) -> String {
         match self {
-            Source::Cli => "cli",
-            Source::Config => "config",
-            Source::Default => "default",
+            Source::Cli => "cli".to_string(),
+            Source::Profile(name) => format!("profile:{}", name),
+            Source::Config => "config".to_string(),
+            Source::Default => "default".to_string(),
         }
     }
 }
@@ -41,6 +43,10 @@ pub struct ConfigCommand {
     pub order: Option<String>,
     /// Concurrency override from CLI.
     pub concurrency: Option<usize>,
+    /// Active profile name (from `--profile` / `INQ_PROFILE`).
+    pub profile: Option<String>,
+    /// When set, list available profiles and exit instead of resolving.
+    pub list_profiles: bool,
 }
 
 impl ConfigCommand {
@@ -53,6 +59,8 @@ impl ConfigCommand {
             no_output_timeout: None,
             order: None,
             concurrency: None,
+            profile: None,
+            list_profiles: false,
         }
     }
 }
@@ -83,7 +91,11 @@ impl Command for ConfigCommand {
     fn execute(&self, ui: &mut dyn UI) -> Result<i32> {
         let base = Path::new(self.base_path.as_deref().unwrap_or("."));
 
-        let loaded = TestrConfig::find_in_directory(base).ok();
+        let loaded = ConfigFile::find_in_directory(base).ok();
+
+        if self.list_profiles {
+            return run_list_profiles(ui, &loaded);
+        }
 
         match &loaded {
             Some((_, path)) => {
@@ -94,41 +106,128 @@ impl Command for ConfigCommand {
             }
         }
         ui.output(&format!("Working directory: {}", base.display()))?;
+
+        // Determine the active profile and the resolved config. When no
+        // config file is present, fall back to defaults so callers can
+        // still see CLI overrides resolved.
+        let (resolved, active_profile, profile_fields) = match &loaded {
+            Some((cfg, _)) => {
+                let (resolved, active) = cfg.resolve(self.profile.as_deref())?;
+                let fields = cfg.fields_from_profile(active.as_deref());
+                (resolved, active, fields)
+            }
+            None => (
+                TestrConfig::default(),
+                None,
+                std::collections::HashSet::new(),
+            ),
+        };
+
+        if let Some(ref name) = active_profile {
+            ui.output(&format!("Active profile: {}", name))?;
+        }
         ui.output("")?;
 
-        let config = loaded.as_ref().map(|(c, _)| c.clone()).unwrap_or_default();
+        let config_or_profile = |key: &str| -> Source {
+            if profile_fields.contains(key) {
+                Source::Profile(active_profile.clone().unwrap_or_default())
+            } else {
+                Source::Config
+            }
+        };
 
-        if !config.test_command.is_empty() {
-            print_value(ui, "test_command", &config.test_command, Source::Config)?;
+        if !resolved.test_command.is_empty() {
+            print_value(
+                ui,
+                "test_command",
+                &resolved.test_command,
+                config_or_profile("test_command"),
+            )?;
         } else {
             print_unset(ui, "test_command", "(unset)")?;
         }
 
-        print_optional_string(ui, "test_id_option", &config.test_id_option)?;
-        print_optional_string(ui, "test_list_option", &config.test_list_option)?;
-        print_optional_string(ui, "test_id_list_default", &config.test_id_list_default)?;
-        print_optional_string(ui, "test_run_concurrency", &config.test_run_concurrency)?;
-        print_optional_string(ui, "filter_tags", &config.filter_tags)?;
-        print_optional_string(ui, "group_regex", &config.group_regex)?;
-        print_optional_string(ui, "instance_provision", &config.instance_provision)?;
-        print_optional_string(ui, "instance_execute", &config.instance_execute)?;
-        print_optional_string(ui, "instance_dispose", &config.instance_dispose)?;
+        print_optional_string(
+            ui,
+            "test_id_option",
+            &resolved.test_id_option,
+            config_or_profile("test_id_option"),
+        )?;
+        print_optional_string(
+            ui,
+            "test_list_option",
+            &resolved.test_list_option,
+            config_or_profile("test_list_option"),
+        )?;
+        print_optional_string(
+            ui,
+            "test_id_list_default",
+            &resolved.test_id_list_default,
+            config_or_profile("test_id_list_default"),
+        )?;
+        print_optional_string(
+            ui,
+            "test_run_concurrency",
+            &resolved.test_run_concurrency,
+            config_or_profile("test_run_concurrency"),
+        )?;
+        print_optional_string(
+            ui,
+            "filter_tags",
+            &resolved.filter_tags,
+            config_or_profile("filter_tags"),
+        )?;
+        print_optional_string(
+            ui,
+            "group_regex",
+            &resolved.group_regex,
+            config_or_profile("group_regex"),
+        )?;
+        print_optional_string(
+            ui,
+            "instance_provision",
+            &resolved.instance_provision,
+            config_or_profile("instance_provision"),
+        )?;
+        print_optional_string(
+            ui,
+            "instance_execute",
+            &resolved.instance_execute,
+            config_or_profile("instance_execute"),
+        )?;
+        print_optional_string(
+            ui,
+            "instance_dispose",
+            &resolved.instance_dispose,
+            config_or_profile("instance_dispose"),
+        )?;
 
-        let (test_timeout_str, src) =
-            resolve_timeout(self.test_timeout.as_deref(), &config.test_timeout)?;
+        let (test_timeout_str, src) = resolve_timeout(
+            self.test_timeout.as_deref(),
+            &resolved.test_timeout,
+            config_or_profile("test_timeout"),
+        )?;
         print_value(ui, "test_timeout", &test_timeout_str, src)?;
 
-        let (max_duration_str, src) =
-            resolve_timeout(self.max_duration.as_deref(), &config.max_duration)?;
+        let (max_duration_str, src) = resolve_timeout(
+            self.max_duration.as_deref(),
+            &resolved.max_duration,
+            config_or_profile("max_duration"),
+        )?;
         print_value(ui, "max_duration", &max_duration_str, src)?;
 
         let (no_output_str, src) = resolve_no_output_timeout(
             self.no_output_timeout.as_deref(),
-            &config.no_output_timeout,
+            &resolved.no_output_timeout,
+            config_or_profile("no_output_timeout"),
         )?;
         print_value(ui, "no_output_timeout", &no_output_str, src)?;
 
-        let (order_str, src) = resolve_order(self.order.as_deref(), &config.test_order)?;
+        let (order_str, src) = resolve_order(
+            self.order.as_deref(),
+            &resolved.test_order,
+            config_or_profile("test_order"),
+        )?;
         print_value(ui, "test_order", &order_str, src)?;
 
         let (concurrency_str, src) = resolve_concurrency(self.concurrency);
@@ -146,6 +245,30 @@ impl Command for ConfigCommand {
     }
 }
 
+fn run_list_profiles(
+    ui: &mut dyn UI,
+    loaded: &Option<(ConfigFile, std::path::PathBuf)>,
+) -> Result<i32> {
+    let Some((cfg, path)) = loaded else {
+        ui.output("Config file: (none found)")?;
+        return Ok(0);
+    };
+    ui.output(&format!("Config file: {}", path.display()))?;
+    let names = cfg.profile_names();
+    if names.is_empty() {
+        ui.output("No profiles defined")?;
+    } else {
+        ui.output("Profiles:")?;
+        for name in names {
+            ui.output(&format!("  {}", name))?;
+        }
+    }
+    if let Some(ref dp) = cfg.default_profile {
+        ui.output(&format!("default_profile: {}", dp))?;
+    }
+    Ok(0)
+}
+
 fn print_value(ui: &mut dyn UI, key: &str, value: &str, src: Source) -> Result<()> {
     ui.output(&format!("{}: {} [{}]", key, value, src.label()))
 }
@@ -154,14 +277,23 @@ fn print_unset(ui: &mut dyn UI, key: &str, placeholder: &str) -> Result<()> {
     ui.output(&format!("{}: {}", key, placeholder))
 }
 
-fn print_optional_string(ui: &mut dyn UI, key: &str, value: &Option<String>) -> Result<()> {
+fn print_optional_string(
+    ui: &mut dyn UI,
+    key: &str,
+    value: &Option<String>,
+    src: Source,
+) -> Result<()> {
     match value {
-        Some(v) => print_value(ui, key, v, Source::Config),
+        Some(v) => print_value(ui, key, v, src),
         None => print_unset(ui, key, "(unset)"),
     }
 }
 
-fn resolve_timeout(cli: Option<&str>, config_value: &Option<String>) -> Result<(String, Source)> {
+fn resolve_timeout(
+    cli: Option<&str>,
+    config_value: &Option<String>,
+    config_source: Source,
+) -> Result<(String, Source)> {
     if let Some(s) = cli {
         let parsed = TimeoutSetting::parse(s)?;
         return Ok((format_timeout(&parsed), Source::Cli));
@@ -169,7 +301,7 @@ fn resolve_timeout(cli: Option<&str>, config_value: &Option<String>) -> Result<(
     match config_value {
         Some(s) => {
             TimeoutSetting::parse(s)?;
-            Ok((s.trim().to_string(), Source::Config))
+            Ok((s.trim().to_string(), config_source))
         }
         None => Ok((format_timeout(&TimeoutSetting::Disabled), Source::Default)),
     }
@@ -178,6 +310,7 @@ fn resolve_timeout(cli: Option<&str>, config_value: &Option<String>) -> Result<(
 fn resolve_no_output_timeout(
     cli: Option<&str>,
     config_value: &Option<String>,
+    config_source: Source,
 ) -> Result<(String, Source)> {
     if let Some(s) = cli {
         let trimmed = s.trim();
@@ -191,17 +324,21 @@ fn resolve_no_output_timeout(
         Some(s) => {
             let trimmed = s.trim();
             if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("disabled") {
-                Ok(("disabled".to_string(), Source::Config))
+                Ok(("disabled".to_string(), config_source))
             } else {
                 crate::config::parse_duration_string(trimmed)?;
-                Ok((trimmed.to_string(), Source::Config))
+                Ok((trimmed.to_string(), config_source))
             }
         }
         None => Ok(("disabled".to_string(), Source::Default)),
     }
 }
 
-fn resolve_order(cli: Option<&str>, config_value: &Option<String>) -> Result<(String, Source)> {
+fn resolve_order(
+    cli: Option<&str>,
+    config_value: &Option<String>,
+    config_source: Source,
+) -> Result<(String, Source)> {
     if let Some(s) = cli {
         let parsed: TestOrder = s.parse()?;
         return Ok((parsed.as_str(), Source::Cli));
@@ -209,7 +346,7 @@ fn resolve_order(cli: Option<&str>, config_value: &Option<String>) -> Result<(St
     match config_value {
         Some(s) => {
             let parsed: TestOrder = s.parse()?;
-            Ok((parsed.as_str(), Source::Config))
+            Ok((parsed.as_str(), config_source))
         }
         None => Ok((TestOrder::Discovery.as_str(), Source::Default)),
     }
@@ -325,6 +462,8 @@ test_order = "alphabetical"
             no_output_timeout: Some("90s".to_string()),
             order: Some("failing-first".to_string()),
             concurrency: Some(4),
+            profile: None,
+            list_profiles: false,
         };
         cmd.execute(&mut ui).unwrap();
 
@@ -363,6 +502,8 @@ test_order = "alphabetical"
             no_output_timeout: None,
             order: None,
             concurrency: None,
+            profile: None,
+            list_profiles: false,
         };
         assert!(cmd.execute(&mut ui).is_err());
     }
@@ -388,5 +529,120 @@ test_order = "alphabetical"
             joined
         );
         assert!(joined.contains("group_regex: (unset)"), "got: {}", joined);
+    }
+
+    #[test]
+    fn profile_overlay_is_labelled() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("inquest.toml"),
+            r#"
+test_command = "echo"
+test_timeout = "1m"
+
+[profiles.ci]
+test_timeout = "5m"
+"#,
+        )
+        .unwrap();
+
+        let mut ui = TestUI::new();
+        let cmd = ConfigCommand {
+            base_path: Some(temp.path().to_string_lossy().to_string()),
+            profile: Some("ci".to_string()),
+            ..ConfigCommand::new(None)
+        };
+        cmd.execute(&mut ui).unwrap();
+
+        let joined = ui.output.join("\n");
+        assert!(joined.contains("Active profile: ci"), "got: {}", joined);
+        assert!(
+            joined.contains("test_timeout: 5m [profile:ci]"),
+            "got: {}",
+            joined
+        );
+        // Untouched base field shows [config], not [profile:ci].
+        assert!(
+            joined.contains("test_command: echo [config]"),
+            "got: {}",
+            joined
+        );
+    }
+
+    #[test]
+    fn list_profiles_lists_names() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("inquest.toml"),
+            r#"
+test_command = "echo"
+default_profile = "ci"
+
+[profiles.ci]
+test_timeout = "5m"
+
+[profiles.nightly]
+test_timeout = "30m"
+"#,
+        )
+        .unwrap();
+
+        let mut ui = TestUI::new();
+        let cmd = ConfigCommand {
+            base_path: Some(temp.path().to_string_lossy().to_string()),
+            list_profiles: true,
+            ..ConfigCommand::new(None)
+        };
+        cmd.execute(&mut ui).unwrap();
+
+        let joined = ui.output.join("\n");
+        assert!(joined.contains("Profiles:"), "got: {}", joined);
+        assert!(joined.contains("  ci"), "got: {}", joined);
+        assert!(joined.contains("  nightly"), "got: {}", joined);
+        assert!(joined.contains("default_profile: ci"), "got: {}", joined);
+    }
+
+    #[test]
+    fn list_profiles_when_none_defined() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join("inquest.toml"), r#"test_command = "echo""#).unwrap();
+
+        let mut ui = TestUI::new();
+        let cmd = ConfigCommand {
+            base_path: Some(temp.path().to_string_lossy().to_string()),
+            list_profiles: true,
+            ..ConfigCommand::new(None)
+        };
+        cmd.execute(&mut ui).unwrap();
+
+        let joined = ui.output.join("\n");
+        assert!(joined.contains("No profiles defined"), "got: {}", joined);
+    }
+
+    #[test]
+    fn unknown_profile_errors() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join("inquest.toml"),
+            r#"
+test_command = "echo"
+
+[profiles.ci]
+test_timeout = "5m"
+"#,
+        )
+        .unwrap();
+
+        let mut ui = TestUI::new();
+        let cmd = ConfigCommand {
+            base_path: Some(temp.path().to_string_lossy().to_string()),
+            profile: Some("nope".to_string()),
+            ..ConfigCommand::new(None)
+        };
+        let err = cmd.execute(&mut ui).unwrap_err().to_string();
+        assert_eq!(
+            err,
+            "Configuration error: profile 'nope' is not defined; available profiles: ci"
+        );
     }
 }

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -46,6 +46,10 @@ impl Command for InfoCommand {
             ui.output(&format!("Command: {}", command))?;
         }
 
+        if let Some(ref profile) = metadata.profile {
+            ui.output(&format!("Profile: {}", profile))?;
+        }
+
         if let Some(concurrency) = metadata.concurrency {
             ui.output(&format!("Concurrency: {}", concurrency))?;
         }
@@ -116,6 +120,7 @@ mod tests {
                 duration_secs: Some(12.5),
                 exit_code: Some(1),
                 test_args: None,
+                profile: None,
             },
         )
         .unwrap();
@@ -159,6 +164,7 @@ mod tests {
                 duration_secs: None,
                 exit_code: Some(0),
                 test_args: None,
+                profile: None,
             },
         )
         .unwrap();

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -100,6 +100,9 @@ pub struct RunCommand {
     /// the MCP server's `inq_cancel` tool stop a run that was handed off
     /// to the caller via `background_after`.
     pub cancellation_token: Option<crate::test_executor::CancellationToken>,
+    /// Active profile name from `--profile` / `INQ_PROFILE` (None = base
+    /// only or `default_profile` from the config file).
+    pub profile: Option<String>,
 }
 
 impl RunCommand {
@@ -169,6 +172,7 @@ impl RunCommand {
     /// If a `stderr_capture` buffer is supplied, its contents are persisted
     /// alongside the run and the buffer is drained so the next iteration
     /// starts clean.
+    #[allow(clippy::too_many_arguments)]
     fn persist(
         &self,
         ui: &mut dyn UI,
@@ -177,6 +181,7 @@ impl RunCommand {
         historical_times: &std::collections::HashMap<crate::repository::TestId, Duration>,
         filter_tags: &[String],
         stderr_capture: Option<&std::sync::Arc<std::sync::Mutex<Vec<u8>>>>,
+        active_profile: Option<&str>,
     ) -> Result<CliRunOutput> {
         let (exit_code, run_id) = crate::commands::utils::persist_and_display_run(
             ui,
@@ -185,6 +190,7 @@ impl RunCommand {
             self.partial,
             historical_times,
             filter_tags,
+            active_profile.map(|s| s.to_string()),
         )?;
         if let Some(buf) = stderr_capture {
             let bytes = match buf.lock() {
@@ -203,7 +209,7 @@ impl RunCommand {
     pub fn execute_returning_run_id(&self, ui: &mut dyn UI) -> Result<CliRunOutput> {
         let base = Path::new(self.base_path.as_deref().unwrap_or("."));
 
-        if self.auto && crate::config::TestrConfig::find_in_directory(base).is_err() {
+        if self.auto && crate::config::ConfigFile::find_in_directory(base).is_err() {
             let auto_cmd = crate::commands::auto::AutoCommand::new(self.base_path.clone());
             let exit_code = auto_cmd.execute(ui)?;
             if exit_code != 0 {
@@ -214,7 +220,12 @@ impl RunCommand {
         let mut repo =
             open_or_init_repository(self.base_path.as_deref(), self.force_init || self.auto, ui)?;
 
-        let test_cmd = TestCommand::from_directory(base)?;
+        let (config_file, _config_path) = crate::config::ConfigFile::find_in_directory(base)?;
+        let (resolved, active_profile) = config_file.resolve(self.profile.as_deref())?;
+        let test_cmd = TestCommand::new(resolved, base.to_path_buf());
+        if let Some(ref name) = active_profile {
+            ui.output(&format!("Using profile: {}", name))?;
+        }
 
         // CLI overrides config; fall back to whatever `filter_tags` is set to
         // in the config file when no CLI flag was given.
@@ -398,6 +409,7 @@ impl RunCommand {
                 &historical_times,
                 &filter_tags,
                 Some(&stderr_capture),
+                active_profile.as_deref(),
             );
         }
 
@@ -474,6 +486,7 @@ impl RunCommand {
                         &historical_times,
                         &filter_tags,
                         Some(&stderr_capture),
+                        active_profile.as_deref(),
                     )?;
 
                     if result.exit_code != 0 {
@@ -499,6 +512,7 @@ impl RunCommand {
                     &historical_times,
                     &filter_tags,
                     Some(&stderr_capture),
+                    active_profile.as_deref(),
                 )
             }
         } else if self.until_failure {
@@ -553,6 +567,7 @@ impl RunCommand {
                     &historical_times,
                     &filter_tags,
                     Some(&stderr_capture),
+                    active_profile.as_deref(),
                 )?;
 
                 if result.exit_code != 0 {
@@ -584,6 +599,7 @@ impl RunCommand {
                 &historical_times,
                 &filter_tags,
                 Some(&stderr_capture),
+                active_profile.as_deref(),
             )
         } else {
             let (run_id, writer) = repo.begin_test_run_raw()?;
@@ -606,6 +622,7 @@ impl RunCommand {
                 &historical_times,
                 &filter_tags,
                 Some(&stderr_capture),
+                active_profile.as_deref(),
             )
         }
     }

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -128,7 +128,8 @@ pub fn update_test_times_from_run(repo: &mut dyn Repository, test_run: &TestRun)
     Ok(())
 }
 
-/// Capture and store run metadata (git commit, command, concurrency, duration, exit code)
+/// Capture and store run metadata (git commit, command, concurrency, duration, exit code).
+#[allow(clippy::too_many_arguments)]
 pub fn store_run_metadata(
     repo: &mut dyn Repository,
     run_id: &RunId,
@@ -137,6 +138,7 @@ pub fn store_run_metadata(
     duration: Option<std::time::Duration>,
     exit_code: Option<i32>,
     test_args: Option<Vec<String>>,
+    profile: Option<String>,
 ) -> Result<()> {
     let git_commit = std::process::Command::new("git")
         .args(["rev-parse", "HEAD"])
@@ -172,6 +174,7 @@ pub fn store_run_metadata(
         duration_secs: duration.map(|d| d.as_secs_f64()),
         exit_code,
         test_args,
+        profile,
     };
 
     repo.set_run_metadata(run_id, metadata)
@@ -293,6 +296,7 @@ pub fn warn_slow_tests(
 ///
 /// Returns `(exit_code, run_id)`. The `run_id` is returned because `output`
 /// is consumed, saving the caller from cloning it beforehand.
+#[allow(clippy::too_many_arguments)]
 pub fn persist_and_display_run(
     ui: &mut dyn UI,
     repo: &mut dyn Repository,
@@ -300,6 +304,7 @@ pub fn persist_and_display_run(
     partial: bool,
     historical_times: &std::collections::HashMap<crate::repository::TestId, std::time::Duration>,
     filter_tags: &[String],
+    profile: Option<String>,
 ) -> Result<(i32, RunId)> {
     let exit_code = output.exit_code();
     let crate::test_executor::RunOutput {
@@ -328,6 +333,7 @@ pub fn persist_and_display_run(
         Some(duration),
         Some(exit_code),
         test_args,
+        profile.clone(),
     )?;
 
     display_test_summary(ui, &run_id, &combined_run, filter_tags)?;
@@ -590,9 +596,16 @@ mod tests {
 
         let mut ui = crate::ui::test_ui::TestUI::new();
         let historical = std::collections::HashMap::new();
-        let (exit_code, run_id) =
-            persist_and_display_run(&mut ui, repo.as_mut(), output, false, &historical, &[])
-                .unwrap();
+        let (exit_code, run_id) = persist_and_display_run(
+            &mut ui,
+            repo.as_mut(),
+            output,
+            false,
+            &historical,
+            &[],
+            None,
+        )
+        .unwrap();
 
         assert_eq!(exit_code, 0);
         assert_eq!(run_id.as_str(), "1");
@@ -672,9 +685,16 @@ mod tests {
 
         let mut ui = crate::ui::test_ui::TestUI::new();
         let historical = std::collections::HashMap::new();
-        let (exit_code, run_id) =
-            persist_and_display_run(&mut ui, repo.as_mut(), output, false, &historical, &[])
-                .unwrap();
+        let (exit_code, run_id) = persist_and_display_run(
+            &mut ui,
+            repo.as_mut(),
+            output,
+            false,
+            &historical,
+            &[],
+            None,
+        )
+        .unwrap();
 
         assert_eq!(exit_code, 1);
         assert_eq!(run_id.as_str(), "0");

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,10 +3,15 @@
 //! Supports three configuration file formats:
 //! - `inquest.toml` or `.inquest.toml` - TOML format (preferred)
 //! - `.testr.conf` - legacy INI format with a `[DEFAULT]` section
+//!
+//! TOML configs may declare named **profiles** under `[profiles.<name>]` to
+//! switch between alternative sets of values (e.g. tighter timeouts for CI).
+//! Top-level fields form the implicit "base" layer; a selected profile
+//! overlays its set fields on top of that base. See [`ConfigFile`].
 
 use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::Path;
 use std::time::Duration;
@@ -150,7 +155,395 @@ pub fn parse_duration_string(s: &str) -> Result<Duration> {
 /// The configuration file names to search for, in order of priority
 pub const CONFIG_FILE_NAMES: &[&str] = &["inquest.toml", ".inquest.toml", ".testr.conf"];
 
-/// Configuration loaded from inquest.toml or .testr.conf
+/// Reserved profile name that refers to the base (top-level) layer.
+pub const DEFAULT_PROFILE_NAME: &str = "default";
+
+/// Environment variable used to select a profile when no `--profile` CLI flag
+/// is given.
+pub const PROFILE_ENV_VAR: &str = "INQ_PROFILE";
+
+/// A single layer of overlayable settings — every field is optional so it can
+/// be merged on top of another layer. Used for profile overlays and as the
+/// shape that `[profiles.<name>]` tables deserialize into.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[serde(default)]
+pub struct ConfigLayer {
+    /// Command line to run to execute tests
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_command: Option<String>,
+    /// The value to substitute into test_command when specific test ids should be run
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_id_option: Option<String>,
+    /// The option to use to cause the test runner to report test ids it would run
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_list_option: Option<String>,
+    /// The value to use for $IDLIST when no specific test ids are being run
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_id_list_default: Option<String>,
+    /// Optional call out to establish concurrency
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_run_concurrency: Option<String>,
+    /// Tags which should be used to filter test counts
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter_tags: Option<String>,
+    /// If set, group tests by the matched section of the test id
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_regex: Option<String>,
+    /// Per-test timeout (e.g. "5m", "auto", "disabled")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_timeout: Option<String>,
+    /// Overall run timeout
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_duration: Option<String>,
+    /// No-output timeout
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_output_timeout: Option<String>,
+    /// Provision one or more test run environments
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance_provision: Option<String>,
+    /// Execute a test runner process in a given environment
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance_execute: Option<String>,
+    /// Dispose of one or more test running environments
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance_dispose: Option<String>,
+    /// Default test ordering strategy
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_order: Option<String>,
+}
+
+impl ConfigLayer {
+    /// Validate per-layer syntactic constraints (durations parse, regex
+    /// compiles, `test_order` names a known strategy). Cross-field checks
+    /// such as `$IDOPTION` requiring `test_id_option` are deferred to the
+    /// resolved config, so that a profile may legally lack `test_command`
+    /// when the base supplies it.
+    fn validate_syntax(&self, context: &str) -> Result<()> {
+        if let Some(ref pattern) = self.group_regex {
+            regex::Regex::new(pattern).map_err(|e| {
+                Error::Config(format!(
+                    "{}: invalid group_regex pattern '{}': {}",
+                    context, pattern, e
+                ))
+            })?;
+        }
+        if let Some(ref s) = self.test_order {
+            s.parse::<crate::ordering::TestOrder>()
+                .map_err(|e| Error::Config(format!("{}: {}", context, prefix_strip(&e))))?;
+        }
+        if let Some(ref s) = self.test_timeout {
+            TimeoutSetting::parse(s).map_err(|e| {
+                Error::Config(format!("{}: test_timeout: {}", context, prefix_strip(&e)))
+            })?;
+        }
+        if let Some(ref s) = self.max_duration {
+            TimeoutSetting::parse(s).map_err(|e| {
+                Error::Config(format!("{}: max_duration: {}", context, prefix_strip(&e)))
+            })?;
+        }
+        if let Some(ref s) = self.no_output_timeout {
+            let trimmed = s.trim();
+            if !(trimmed.is_empty() || trimmed.eq_ignore_ascii_case("disabled")) {
+                parse_duration_string(trimmed).map_err(|e| {
+                    Error::Config(format!(
+                        "{}: no_output_timeout: {}",
+                        context,
+                        prefix_strip(&e)
+                    ))
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Apply `other` on top of `self` in place. `Some(_)` values in `other`
+    /// (including `Some("")`) override `self`; `None` leaves `self` intact.
+    fn overlay(&mut self, other: &ConfigLayer) {
+        macro_rules! overlay_field {
+            ($field:ident) => {
+                if let Some(ref v) = other.$field {
+                    self.$field = Some(v.clone());
+                }
+            };
+        }
+        overlay_field!(test_command);
+        overlay_field!(test_id_option);
+        overlay_field!(test_list_option);
+        overlay_field!(test_id_list_default);
+        overlay_field!(test_run_concurrency);
+        overlay_field!(filter_tags);
+        overlay_field!(group_regex);
+        overlay_field!(test_timeout);
+        overlay_field!(max_duration);
+        overlay_field!(no_output_timeout);
+        overlay_field!(instance_provision);
+        overlay_field!(instance_execute);
+        overlay_field!(instance_dispose);
+        overlay_field!(test_order);
+    }
+}
+
+/// A parsed configuration file: a base layer plus optional named profiles.
+///
+/// Top-level TOML fields populate `base` (the existing flat layout).
+/// `[profiles.<name>]` tables define overlayable variants. Use
+/// [`ConfigFile::resolve`] to apply a selected profile and produce a
+/// [`TestrConfig`] suitable for downstream consumers.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct ConfigFile {
+    /// The base / default layer — top-level fields in the TOML file.
+    #[serde(flatten)]
+    pub base: ConfigLayer,
+    /// Name of the profile applied when no `--profile` flag and no
+    /// `INQ_PROFILE` env var are set. Must reference a defined profile or
+    /// the reserved name "default".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_profile: Option<String>,
+    /// Named profile layers. `BTreeMap` so listings and error messages are
+    /// deterministic.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub profiles: BTreeMap<String, ConfigLayer>,
+}
+
+impl ConfigFile {
+    /// Load a `ConfigFile` from a path. TOML parses with full profile support;
+    /// legacy `.testr.conf` parses into a `ConfigFile` with no profiles and
+    /// no `default_profile`.
+    pub fn load_from_file(path: &Path) -> Result<Self> {
+        let contents = fs::read_to_string(path)
+            .map_err(|e| Error::Config(format!("Failed to read {}: {}", path.display(), e)))?;
+        let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if file_name.ends_with(".toml") {
+            Self::parse_toml(&contents)
+        } else {
+            Self::parse_ini(&contents)
+        }
+    }
+
+    /// Search `dir` for a config file (in `CONFIG_FILE_NAMES` priority order)
+    /// and load it. Returns the parsed file and its path.
+    pub fn find_in_directory(dir: &Path) -> Result<(Self, std::path::PathBuf)> {
+        for name in CONFIG_FILE_NAMES {
+            let path = dir.join(name);
+            if path.exists() {
+                let cfg = Self::load_from_file(&path)?;
+                return Ok((cfg, path));
+            }
+        }
+        Err(Error::Config(format!(
+            "No configuration file found (looked for {})",
+            CONFIG_FILE_NAMES.join(", ")
+        )))
+    }
+
+    /// Parse a TOML config string with full profile support.
+    pub fn parse_toml(contents: &str) -> Result<Self> {
+        let cfg: ConfigFile = toml::from_str(contents)
+            .map_err(|e| Error::Config(format!("Failed to parse TOML config: {}", e)))?;
+        cfg.validate_syntax()?;
+        Ok(cfg)
+    }
+
+    /// Parse legacy INI (`.testr.conf`) into a `ConfigFile`. The INI format
+    /// has no profile support; the parsed values populate the base layer.
+    pub fn parse_ini(contents: &str) -> Result<Self> {
+        let base = parse_ini_base(contents)?;
+        let cfg = ConfigFile {
+            base,
+            default_profile: None,
+            profiles: BTreeMap::new(),
+        };
+        cfg.validate_syntax()?;
+        Ok(cfg)
+    }
+
+    /// Per-layer syntactic validation plus profile-name validation. This
+    /// runs without merging, so `inq config --list-profiles` succeeds even
+    /// when the base lacks a `test_command`.
+    fn validate_syntax(&self) -> Result<()> {
+        self.base.validate_syntax("base config")?;
+        for (name, layer) in &self.profiles {
+            validate_profile_name(name)?;
+            layer.validate_syntax(&format!("profile '{}'", name))?;
+        }
+        if let Some(ref name) = self.default_profile {
+            if name != DEFAULT_PROFILE_NAME && !self.profiles.contains_key(name) {
+                return Err(Error::Config(format!(
+                    "default_profile '{}' is not defined; {}",
+                    name,
+                    self.available_profiles_message()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Return profile names in deterministic order.
+    pub fn profile_names(&self) -> Vec<&str> {
+        self.profiles.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Resolve to a `TestrConfig` by overlaying the selected profile on the
+    /// base layer.
+    ///
+    /// Selection precedence (highest first):
+    ///   1. the explicit `selected` argument (`--profile` CLI flag or
+    ///      `INQ_PROFILE` env var resolved by the caller).
+    ///   2. the file's `default_profile` field, if present.
+    ///   3. base only (no overlay).
+    ///
+    /// Returns `(TestrConfig, active_profile_name)`. The active profile name
+    /// is `None` when no profile was applied.
+    pub fn resolve(&self, selected: Option<&str>) -> Result<(TestrConfig, Option<String>)> {
+        let active = match selected {
+            Some(name) => Some(name.to_string()),
+            None => self.default_profile.clone(),
+        };
+
+        let active = match active {
+            None => None,
+            Some(ref name) if name == DEFAULT_PROFILE_NAME => None,
+            Some(name) => {
+                if !self.profiles.contains_key(&name) {
+                    return Err(Error::Config(format!(
+                        "profile '{}' is not defined; {}",
+                        name,
+                        self.available_profiles_message()
+                    )));
+                }
+                Some(name)
+            }
+        };
+
+        let mut merged = self.base.clone();
+        if let Some(ref name) = active {
+            merged.overlay(&self.profiles[name]);
+        }
+
+        let resolved = TestrConfig::from_resolved_layer(merged)?;
+        Ok((resolved, active))
+    }
+
+    /// Mark which fields in the resolved layer originated from the active
+    /// profile (vs. the base layer). Used by `inq config` for source
+    /// annotation. Returns a set of field names that the profile overrode.
+    pub fn fields_from_profile(
+        &self,
+        profile: Option<&str>,
+    ) -> std::collections::HashSet<&'static str> {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        let Some(name) = profile else {
+            return set;
+        };
+        if name == DEFAULT_PROFILE_NAME {
+            return set;
+        }
+        let Some(layer) = self.profiles.get(name) else {
+            return set;
+        };
+        macro_rules! check {
+            ($field:ident) => {
+                if layer.$field.is_some() {
+                    set.insert(stringify!($field));
+                }
+            };
+        }
+        check!(test_command);
+        check!(test_id_option);
+        check!(test_list_option);
+        check!(test_id_list_default);
+        check!(test_run_concurrency);
+        check!(filter_tags);
+        check!(group_regex);
+        check!(test_timeout);
+        check!(max_duration);
+        check!(no_output_timeout);
+        check!(instance_provision);
+        check!(instance_execute);
+        check!(instance_dispose);
+        check!(test_order);
+        set
+    }
+
+    fn available_profiles_message(&self) -> String {
+        if self.profiles.is_empty() {
+            "no profiles are defined".to_string()
+        } else {
+            format!("available profiles: {}", self.profile_names().join(", "))
+        }
+    }
+}
+
+/// Strip a redundant `Configuration error: ` prefix from a nested
+/// `Error::Config` so we can re-wrap without duplicating the leader.
+fn prefix_strip(e: &Error) -> String {
+    let s = e.to_string();
+    s.strip_prefix("Configuration error: ")
+        .unwrap_or(&s)
+        .to_string()
+}
+
+fn validate_profile_name(name: &str) -> Result<()> {
+    if name == DEFAULT_PROFILE_NAME {
+        return Err(Error::Config(format!(
+            "[profiles.{}] is reserved; the top-level table is the implicit default",
+            DEFAULT_PROFILE_NAME
+        )));
+    }
+    if name.is_empty() {
+        return Err(Error::Config("profile name must not be empty".to_string()));
+    }
+    if name.starts_with('_') {
+        return Err(Error::Config(format!(
+            "invalid profile name '{}': must not start with '_'",
+            name
+        )));
+    }
+    if name
+        .chars()
+        .any(|c| c == '.' || c == '/' || c.is_whitespace())
+    {
+        return Err(Error::Config(format!(
+            "invalid profile name '{}': must not contain '.', '/', or whitespace",
+            name
+        )));
+    }
+    Ok(())
+}
+
+fn parse_ini_base(contents: &str) -> Result<ConfigLayer> {
+    let ini: HashMap<String, HashMap<String, String>> = serde_ini::from_str(contents)
+        .map_err(|e| Error::Config(format!("Failed to parse .testr.conf: {}", e)))?;
+    let default = ini
+        .get("DEFAULT")
+        .ok_or_else(|| Error::Config("No [DEFAULT] section in .testr.conf".to_string()))?;
+    Ok(ConfigLayer {
+        test_command: default.get("test_command").cloned(),
+        test_id_option: default.get("test_id_option").cloned(),
+        test_list_option: default.get("test_list_option").cloned(),
+        test_id_list_default: default.get("test_id_list_default").cloned(),
+        test_run_concurrency: default.get("test_run_concurrency").cloned(),
+        filter_tags: default.get("filter_tags").cloned(),
+        group_regex: default.get("group_regex").cloned(),
+        test_timeout: default.get("test_timeout").cloned(),
+        max_duration: default.get("max_duration").cloned(),
+        no_output_timeout: default.get("no_output_timeout").cloned(),
+        instance_provision: default.get("instance_provision").cloned(),
+        instance_execute: default.get("instance_execute").cloned(),
+        instance_dispose: default.get("instance_dispose").cloned(),
+        test_order: default.get("test_order").cloned(),
+    })
+}
+
+/// Configuration loaded from inquest.toml or .testr.conf (post-resolution).
+///
+/// This is the shape downstream code consumes — produced by
+/// [`ConfigFile::resolve`] after applying any active profile overlay. For
+/// backward compatibility, [`TestrConfig::find_in_directory`],
+/// [`TestrConfig::load_from_file`], [`TestrConfig::parse_toml`], and
+/// [`TestrConfig::parse_ini`] still load and return a base-only resolved
+/// config.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct TestrConfig {
@@ -200,47 +593,30 @@ pub struct TestrConfig {
 }
 
 impl TestrConfig {
-    /// Load configuration from a config file, detecting format from the file extension
+    /// Load configuration from a config file, detecting format from the file
+    /// extension. Returns a base-only resolved config (no profile overlay).
+    /// For profile-aware loading, use [`ConfigFile::load_from_file`].
     pub fn load_from_file(path: &Path) -> Result<Self> {
-        let contents = fs::read_to_string(path)
-            .map_err(|e| Error::Config(format!("Failed to read {}: {}", path.display(), e)))?;
-
-        let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-
-        if file_name.ends_with(".toml") {
-            Self::parse_toml(&contents)
-        } else {
-            Self::parse_ini(&contents)
-        }
+        let cfg = ConfigFile::load_from_file(path)?;
+        let (resolved, _active) = cfg.resolve(None)?;
+        Ok(resolved)
     }
 
-    /// Find and load the configuration file from a directory.
-    ///
-    /// Searches for config files in order of priority:
-    /// `inquest.toml`, `.inquest.toml`, `.testr.conf`
-    ///
-    /// Returns the parsed config and the path to the file that was loaded.
+    /// Find and load the configuration file from a directory. Returns a
+    /// base-only resolved config. For profile-aware loading use
+    /// [`ConfigFile::find_in_directory`] followed by [`ConfigFile::resolve`].
     pub fn find_in_directory(dir: &Path) -> Result<(Self, std::path::PathBuf)> {
-        for name in CONFIG_FILE_NAMES {
-            let path = dir.join(name);
-            if path.exists() {
-                let config = Self::load_from_file(&path)?;
-                return Ok((config, path));
-            }
-        }
-
-        Err(Error::Config(format!(
-            "No configuration file found (looked for {})",
-            CONFIG_FILE_NAMES.join(", ")
-        )))
+        let (cfg, path) = ConfigFile::find_in_directory(dir)?;
+        let (resolved, _active) = cfg.resolve(None)?;
+        Ok((resolved, path))
     }
 
-    /// Parse configuration from a TOML string
+    /// Parse a TOML string and resolve to a base-only config (no profile
+    /// overlay). For profile-aware parsing use [`ConfigFile::parse_toml`].
     pub fn parse_toml(contents: &str) -> Result<Self> {
-        let config: TestrConfig = toml::from_str(contents)
-            .map_err(|e| Error::Config(format!("Failed to parse TOML config: {}", e)))?;
-
-        Self::validate(config)
+        let cfg = ConfigFile::parse_toml(contents)?;
+        let (resolved, _active) = cfg.resolve(None)?;
+        Ok(resolved)
     }
 
     /// Serialize the configuration to a TOML string. Fields with `None` values
@@ -250,38 +626,11 @@ impl TestrConfig {
             .map_err(|e| Error::Config(format!("Failed to serialize TOML config: {}", e)))
     }
 
-    /// Parse configuration from an INI string (legacy .testr.conf format)
+    /// Parse a legacy `.testr.conf` (INI) string into a resolved config.
     pub fn parse_ini(contents: &str) -> Result<Self> {
-        // Parse as INI format
-        let ini: HashMap<String, HashMap<String, String>> = serde_ini::from_str(contents)
-            .map_err(|e| Error::Config(format!("Failed to parse .testr.conf: {}", e)))?;
-
-        // Extract DEFAULT section
-        let default = ini
-            .get("DEFAULT")
-            .ok_or_else(|| Error::Config("No [DEFAULT] section in .testr.conf".to_string()))?;
-
-        let config = TestrConfig {
-            test_command: default
-                .get("test_command")
-                .ok_or_else(|| Error::Config("No test_command option in .testr.conf".to_string()))?
-                .clone(),
-            test_id_option: default.get("test_id_option").cloned(),
-            test_list_option: default.get("test_list_option").cloned(),
-            test_id_list_default: default.get("test_id_list_default").cloned(),
-            test_run_concurrency: default.get("test_run_concurrency").cloned(),
-            filter_tags: default.get("filter_tags").cloned(),
-            group_regex: default.get("group_regex").cloned(),
-            test_timeout: default.get("test_timeout").cloned(),
-            max_duration: default.get("max_duration").cloned(),
-            no_output_timeout: default.get("no_output_timeout").cloned(),
-            instance_provision: default.get("instance_provision").cloned(),
-            instance_execute: default.get("instance_execute").cloned(),
-            instance_dispose: default.get("instance_dispose").cloned(),
-            test_order: default.get("test_order").cloned(),
-        };
-
-        Self::validate(config)
+        let cfg = ConfigFile::parse_ini(contents)?;
+        let (resolved, _active) = cfg.resolve(None)?;
+        Ok(resolved)
     }
 
     /// Parse configuration from an INI string (legacy .testr.conf format)
@@ -291,40 +640,40 @@ impl TestrConfig {
         Self::parse_ini(contents)
     }
 
-    /// Validate a parsed configuration
-    fn validate(config: TestrConfig) -> Result<TestrConfig> {
-        // Validate required fields
-        if config.test_command.is_empty() {
+    /// Build a resolved `TestrConfig` from a fully-overlaid `ConfigLayer`.
+    /// Performs cross-field validation (`test_command` non-empty,
+    /// `$IDOPTION` ⇒ `test_id_option` set, etc.) on the merged result.
+    pub(crate) fn from_resolved_layer(layer: ConfigLayer) -> Result<Self> {
+        let test_command = layer.test_command.unwrap_or_default();
+        if test_command.is_empty() {
             return Err(Error::Config("test_command cannot be empty".to_string()));
         }
-
-        // Validate that if $IDOPTION is used, test_id_option is configured
-        if config.test_command.contains("$IDOPTION") && config.test_id_option.is_none() {
+        if test_command.contains("$IDOPTION") && layer.test_id_option.is_none() {
             return Err(Error::Config(
                 "test_command uses $IDOPTION but test_id_option is not configured".to_string(),
             ));
         }
-
-        // Validate that if $LISTOPT is used, test_list_option is configured
-        if config.test_command.contains("$LISTOPT") && config.test_list_option.is_none() {
+        if test_command.contains("$LISTOPT") && layer.test_list_option.is_none() {
             return Err(Error::Config(
                 "test_command uses $LISTOPT but test_list_option is not configured".to_string(),
             ));
         }
-
-        // Validate group_regex is a valid regex pattern
-        if let Some(ref pattern) = config.group_regex {
-            regex::Regex::new(pattern).map_err(|e| {
-                Error::Config(format!("invalid group_regex pattern '{}': {}", pattern, e))
-            })?;
-        }
-
-        // Validate test_order is a recognised strategy
-        if let Some(ref s) = config.test_order {
-            s.parse::<crate::ordering::TestOrder>()?;
-        }
-
-        Ok(config)
+        Ok(TestrConfig {
+            test_command,
+            test_id_option: layer.test_id_option,
+            test_list_option: layer.test_list_option,
+            test_id_list_default: layer.test_id_list_default,
+            test_run_concurrency: layer.test_run_concurrency,
+            filter_tags: layer.filter_tags,
+            group_regex: layer.group_regex,
+            test_timeout: layer.test_timeout,
+            max_duration: layer.max_duration,
+            no_output_timeout: layer.no_output_timeout,
+            instance_provision: layer.instance_provision,
+            instance_execute: layer.instance_execute,
+            instance_dispose: layer.instance_dispose,
+            test_order: layer.test_order,
+        })
     }
 
     /// Parse the configured test ordering, or return the default if unset.
@@ -818,5 +1167,357 @@ filter_tags = "worker-0  !slow"
             config.parsed_filter_tags(),
             vec!["worker-0".to_string(), "!slow".to_string()]
         );
+    }
+
+    // ----- Profile tests -----
+
+    #[test]
+    fn profile_overlay_overrides_base_fields() {
+        let cfg = ConfigFile::parse_toml(
+            r#"
+test_command = "python -m test"
+test_timeout = "1m"
+test_order = "discovery"
+
+[profiles.ci]
+test_timeout = "5m"
+test_order = "alphabetical"
+"#,
+        )
+        .unwrap();
+
+        let (resolved, active) = cfg.resolve(Some("ci")).unwrap();
+        assert_eq!(active.as_deref(), Some("ci"));
+        assert_eq!(resolved.test_command, "python -m test");
+        assert_eq!(resolved.test_timeout.as_deref(), Some("5m"));
+        assert_eq!(resolved.test_order.as_deref(), Some("alphabetical"));
+    }
+
+    #[test]
+    fn profile_overlay_leaves_unset_fields_alone() {
+        let cfg = ConfigFile::parse_toml(
+            r#"
+test_command = "python -m test"
+filter_tags = "worker-0"
+
+[profiles.ci]
+test_timeout = "5m"
+"#,
+        )
+        .unwrap();
+
+        let (resolved, _) = cfg.resolve(Some("ci")).unwrap();
+        assert_eq!(resolved.filter_tags.as_deref(), Some("worker-0"));
+        assert_eq!(resolved.test_timeout.as_deref(), Some("5m"));
+    }
+
+    #[test]
+    fn profile_empty_string_overrides_base() {
+        // A profile setting `filter_tags = ""` should clear the base value,
+        // not be treated as "unset, use base".
+        let cfg = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+filter_tags = "worker-0"
+
+[profiles.nightly]
+filter_tags = ""
+"#,
+        )
+        .unwrap();
+
+        let (resolved, _) = cfg.resolve(Some("nightly")).unwrap();
+        assert_eq!(resolved.filter_tags.as_deref(), Some(""));
+        assert_eq!(resolved.parsed_filter_tags(), Vec::<String>::new());
+    }
+
+    #[test]
+    fn profile_resolve_default_returns_base() {
+        let cfg = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+test_timeout = "1m"
+
+[profiles.ci]
+test_timeout = "5m"
+"#,
+        )
+        .unwrap();
+
+        let (resolved, active) = cfg.resolve(None).unwrap();
+        assert!(active.is_none());
+        assert_eq!(resolved.test_timeout.as_deref(), Some("1m"));
+    }
+
+    #[test]
+    fn profile_default_keyword_is_base() {
+        let cfg = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+test_timeout = "1m"
+
+[profiles.ci]
+test_timeout = "5m"
+"#,
+        )
+        .unwrap();
+
+        let (resolved, active) = cfg.resolve(Some("default")).unwrap();
+        assert!(active.is_none());
+        assert_eq!(resolved.test_timeout.as_deref(), Some("1m"));
+    }
+
+    #[test]
+    fn profile_unknown_name_is_an_error() {
+        let cfg = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+
+[profiles.ci]
+test_timeout = "5m"
+"#,
+        )
+        .unwrap();
+
+        let err = cfg.resolve(Some("nope")).unwrap_err().to_string();
+        assert_eq!(
+            err,
+            "Configuration error: profile 'nope' is not defined; available profiles: ci"
+        );
+    }
+
+    #[test]
+    fn profile_unknown_name_with_no_profiles_defined() {
+        let cfg = ConfigFile::parse_toml(r#"test_command = "echo""#).unwrap();
+        let err = cfg.resolve(Some("nope")).unwrap_err().to_string();
+        assert_eq!(
+            err,
+            "Configuration error: profile 'nope' is not defined; no profiles are defined"
+        );
+    }
+
+    #[test]
+    fn profiles_default_is_reserved() {
+        let err = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+
+[profiles.default]
+test_timeout = "5m"
+"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert_eq!(
+            err,
+            "Configuration error: [profiles.default] is reserved; the top-level table is the implicit default"
+        );
+    }
+
+    #[test]
+    fn invalid_profile_name_is_rejected() {
+        let err = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+
+[profiles."has space"]
+test_timeout = "5m"
+"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert_eq!(
+            err,
+            "Configuration error: invalid profile name 'has space': must not contain '.', '/', or whitespace"
+        );
+    }
+
+    #[test]
+    fn profile_name_starting_with_underscore_is_rejected() {
+        let err = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+
+[profiles._internal]
+test_timeout = "5m"
+"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert_eq!(
+            err,
+            "Configuration error: invalid profile name '_internal': must not start with '_'"
+        );
+    }
+
+    #[test]
+    fn default_profile_must_exist() {
+        let err = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+default_profile = "nope"
+
+[profiles.ci]
+test_timeout = "5m"
+"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert_eq!(
+            err,
+            "Configuration error: default_profile 'nope' is not defined; available profiles: ci"
+        );
+    }
+
+    #[test]
+    fn default_profile_applies_when_no_selection() {
+        let cfg = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+test_timeout = "1m"
+default_profile = "ci"
+
+[profiles.ci]
+test_timeout = "5m"
+"#,
+        )
+        .unwrap();
+
+        let (resolved, active) = cfg.resolve(None).unwrap();
+        assert_eq!(active.as_deref(), Some("ci"));
+        assert_eq!(resolved.test_timeout.as_deref(), Some("5m"));
+    }
+
+    #[test]
+    fn explicit_selection_overrides_default_profile() {
+        let cfg = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+default_profile = "ci"
+
+[profiles.ci]
+test_timeout = "5m"
+
+[profiles.dev]
+test_timeout = "10m"
+"#,
+        )
+        .unwrap();
+
+        let (resolved, active) = cfg.resolve(Some("dev")).unwrap();
+        assert_eq!(active.as_deref(), Some("dev"));
+        assert_eq!(resolved.test_timeout.as_deref(), Some("10m"));
+    }
+
+    #[test]
+    fn profile_can_supply_test_command_when_base_lacks_it() {
+        let cfg = ConfigFile::parse_toml(
+            r#"
+[profiles.ci]
+test_command = "python -m test"
+"#,
+        )
+        .unwrap();
+
+        // Base alone would fail cross-field validation (no test_command)…
+        assert!(cfg.resolve(None).is_err());
+        // …but the profile supplies it.
+        let (resolved, _) = cfg.resolve(Some("ci")).unwrap();
+        assert_eq!(resolved.test_command, "python -m test");
+    }
+
+    #[test]
+    fn profile_per_layer_validation_catches_bad_test_order() {
+        let err = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+
+[profiles.ci]
+test_order = "bogus"
+"#,
+        )
+        .unwrap_err()
+        .to_string();
+        assert_eq!(
+            err,
+            "Configuration error: profile 'ci': unknown test order 'bogus': \
+             expected one of auto, discovery, alphabetical, failing-first, spread, \
+             shuffle[:<seed>], slowest-first, fastest-first, frequent-failing-first"
+        );
+    }
+
+    #[test]
+    fn fields_from_profile_reports_overlaid_keys() {
+        let cfg = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+filter_tags = "worker-0"
+
+[profiles.ci]
+test_timeout = "5m"
+filter_tags = ""
+"#,
+        )
+        .unwrap();
+        let mut from: Vec<&str> = cfg.fields_from_profile(Some("ci")).into_iter().collect();
+        from.sort();
+        assert_eq!(from, vec!["filter_tags", "test_timeout"]);
+    }
+
+    #[test]
+    fn fields_from_profile_empty_when_no_profile_active() {
+        let cfg = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+
+[profiles.ci]
+test_timeout = "5m"
+"#,
+        )
+        .unwrap();
+        let from: Vec<&str> = cfg.fields_from_profile(None).into_iter().collect();
+        assert_eq!(from, Vec::<&str>::new());
+
+        let from: Vec<&str> = cfg
+            .fields_from_profile(Some("default"))
+            .into_iter()
+            .collect();
+        assert_eq!(from, Vec::<&str>::new());
+    }
+
+    #[test]
+    fn profile_names_are_deterministically_ordered() {
+        let cfg = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+
+[profiles.zeta]
+test_timeout = "1m"
+
+[profiles.alpha]
+test_timeout = "2m"
+"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.profile_names(), vec!["alpha", "zeta"]);
+    }
+
+    #[test]
+    fn flat_toml_still_loads_unchanged() {
+        // Backwards compatibility: flat layout without any profiles.
+        let cfg = ConfigFile::parse_toml(
+            r#"
+test_command = "cargo subunit $LISTOPT $IDOPTION"
+test_id_option = "--load-list $IDFILE"
+test_list_option = "--list"
+"#,
+        )
+        .unwrap();
+        assert!(cfg.profiles.is_empty());
+        assert!(cfg.default_profile.is_none());
+
+        let (resolved, active) = cfg.resolve(None).unwrap();
+        assert!(active.is_none());
+        assert_eq!(resolved.test_command, "cargo subunit $LISTOPT $IDOPTION");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,12 @@ struct Cli {
     #[arg(short = 'C', long, global = true, value_hint = ValueHint::DirPath)]
     directory: Option<String>,
 
+    /// Select a named profile from inquest.toml. Falls back to the
+    /// `INQ_PROFILE` environment variable, then `default_profile`
+    /// from the config file. Use "default" to force the base layer.
+    #[arg(long, global = true, value_name = "NAME")]
+    profile: Option<String>,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -89,6 +95,10 @@ enum Commands {
         /// Number of parallel test workers
         #[arg(long, short = 'j', value_name = "N", alias = "concurrency", num_args = 0..=1, default_missing_value = "0")]
         parallel: Option<usize>,
+
+        /// List defined profile names from the config file and exit
+        #[arg(long)]
+        list_profiles: bool,
     },
 
     /// Show quickstart documentation
@@ -411,6 +421,14 @@ fn main() {
 
     let mut ui = CliUI;
 
+    // CLI flag wins over the env var; the config file's `default_profile`
+    // is only consulted when neither is set, and that lookup happens
+    // inside `ConfigFile::resolve`.
+    let profile = cli
+        .profile
+        .clone()
+        .or_else(|| std::env::var(inquest::config::PROFILE_ENV_VAR).ok());
+
     let command = cli.command.unwrap_or(Commands::Run {
         failing: false,
         force_init: false,
@@ -475,6 +493,7 @@ fn main() {
             no_output_timeout,
             order,
             parallel,
+            list_profiles,
         } => {
             let cmd = ConfigCommand {
                 base_path: cli.directory,
@@ -483,6 +502,8 @@ fn main() {
                 no_output_timeout,
                 order,
                 concurrency: parallel,
+                profile: profile.clone(),
+                list_profiles,
             };
             cmd.execute(&mut ui)
         }
@@ -759,6 +780,7 @@ fn main() {
                 run_id_slot: None,
                 cancellation_token: None,
                 test_ids_override: None,
+                profile: profile.clone(),
             };
             cmd.execute(&mut ui)
         }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -814,6 +814,12 @@ struct ConfigResponse {
     supports_listing: bool,
     /// When true, inq_run can run a specific subset of tests by ID.
     supports_targeted_runs: bool,
+    /// Names of all profiles defined in the config file. Empty when the
+    /// file has no `[profiles.*]` tables.
+    available_profiles: Vec<String>,
+    /// `default_profile` from the config file (omitted if unset).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default_profile: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     test_list_option: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1682,6 +1688,7 @@ impl InquestMcpService {
                                     partial,
                                     &historical_times,
                                     &[],
+                                    None,
                                 ) {
                                     tracing::error!(
                                         "Failed to persist background run results: {}",
@@ -1975,10 +1982,19 @@ impl InquestMcpService {
         annotations(read_only_hint = true, idempotent_hint = true, open_world_hint = false)
     )]
     async fn inq_config(&self) -> Result<CallToolResult, ErrorData> {
-        let (config, config_path) = crate::config::TestrConfig::find_in_directory(&self.directory)
+        let (cfg, config_path) = crate::config::ConfigFile::find_in_directory(&self.directory)
             .map_err(|e| {
                 ErrorData::invalid_params(format!("Failed to load test config: {}", e), None)
             })?;
+        let available_profiles = cfg
+            .profile_names()
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        let default_profile = cfg.default_profile.clone();
+        let (config, _active) = cfg.resolve(None).map_err(|e| {
+            ErrorData::invalid_params(format!("Failed to resolve config: {}", e), None)
+        })?;
 
         ok_json(&ConfigResponse {
             config_path: config_path.to_string_lossy().into_owned(),
@@ -1993,6 +2009,8 @@ impl InquestMcpService {
             no_output_timeout: config.no_output_timeout,
             group_regex: config.group_regex,
             test_run_concurrency: config.test_run_concurrency,
+            available_profiles,
+            default_profile,
         })
     }
 
@@ -2547,6 +2565,7 @@ mod tests {
                 duration_secs: Some(5.0),
                 exit_code: Some(1),
                 test_args: None,
+                profile: None,
             },
         )
         .unwrap();

--- a/src/repository/inquest.rs
+++ b/src/repository/inquest.rs
@@ -165,7 +165,8 @@ fn create_schema(conn: &rusqlite::Connection) -> Result<()> {
             failures INTEGER NOT NULL DEFAULT 0,
             errors INTEGER NOT NULL DEFAULT 0,
             skips INTEGER NOT NULL DEFAULT 0,
-            test_args TEXT
+            test_args TEXT,
+            profile TEXT
         );
 
         CREATE TABLE test_results (
@@ -229,6 +230,7 @@ fn migrate_schema(conn: &rusqlite::Connection) -> Result<()> {
     add_column_if_missing(conn, "runs", "exit_code", "INTEGER");
     add_column_if_missing(conn, "runs", "git_dirty", "INTEGER");
     add_column_if_missing(conn, "runs", "test_args", "TEXT");
+    add_column_if_missing(conn, "runs", "profile", "TEXT");
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS test_results_test_id_run_id \
          ON test_results (test_id, run_id);
@@ -687,7 +689,7 @@ impl Repository for InquestRepository {
 
     fn get_run_metadata(&self, run_id: &RunId) -> Result<RunMetadata> {
         let result = self.conn.query_row(
-            "SELECT git_commit, git_dirty, command, concurrency, duration_secs, exit_code, test_args FROM runs WHERE id = ?",
+            "SELECT git_commit, git_dirty, command, concurrency, duration_secs, exit_code, test_args, profile FROM runs WHERE id = ?",
             [run_id.as_str()],
             |row| {
                 let test_args_json: Option<String> = row.get(6)?;
@@ -702,6 +704,7 @@ impl Repository for InquestRepository {
                     duration_secs: row.get(4)?,
                     exit_code: row.get(5)?,
                     test_args,
+                    profile: row.get(7)?,
                 })
             },
         );
@@ -832,7 +835,7 @@ impl Repository for InquestRepository {
             .transpose()
             .map_err(|e| Error::Other(format!("Failed to serialize test_args: {}", e)))?;
         self.conn.execute(
-            "UPDATE runs SET git_commit = ?, git_dirty = ?, command = ?, concurrency = ?, duration_secs = ?, exit_code = ?, test_args = ? WHERE id = ?",
+            "UPDATE runs SET git_commit = ?, git_dirty = ?, command = ?, concurrency = ?, duration_secs = ?, exit_code = ?, test_args = ?, profile = ? WHERE id = ?",
             params![
                 metadata.git_commit,
                 metadata.git_dirty,
@@ -841,6 +844,7 @@ impl Repository for InquestRepository {
                 metadata.duration_secs,
                 metadata.exit_code,
                 test_args_json,
+                metadata.profile,
                 run_id.as_str(),
             ],
         )?;
@@ -1483,6 +1487,7 @@ mod tests {
                 duration_secs: Some(12.5),
                 exit_code: Some(1),
                 test_args: Some(vec!["-x".to_string(), "--maxfail=3".to_string()]),
+                profile: None,
             },
         )
         .unwrap();
@@ -1743,6 +1748,7 @@ mod tests {
                 duration_secs: Some(45.3),
                 exit_code: Some(0),
                 test_args: None,
+                profile: None,
             },
         )
         .unwrap();

--- a/src/repository/test_run.rs
+++ b/src/repository/test_run.rs
@@ -344,6 +344,10 @@ pub struct RunMetadata {
     /// Extra arguments passed to the test command after `--`. Captured so
     /// `inq rerun` can reproduce the original invocation.
     pub test_args: Option<Vec<String>>,
+    /// Active profile name from `--profile` / `INQ_PROFILE` /
+    /// `default_profile`, when one was applied. `None` for runs that used
+    /// the base layer alone, including all runs predating profile support.
+    pub profile: Option<String>,
 }
 
 /// A complete test run containing results for multiple tests.

--- a/src/testcommand.rs
+++ b/src/testcommand.rs
@@ -3,7 +3,7 @@
 //! This module provides the TestCommand struct which handles executing
 //! test commands based on configuration from inquest.toml or .testr.conf.
 
-use crate::config::TestrConfig;
+use crate::config::{ConfigFile, TestrConfig};
 use crate::error::{Error, Result};
 use crate::repository::TestId;
 use std::collections::HashMap;
@@ -31,6 +31,17 @@ impl TestCommand {
     pub fn from_directory(dir: &Path) -> Result<Self> {
         let (config, _path) = TestrConfig::find_in_directory(dir)?;
         Ok(TestCommand::new(config, dir.to_path_buf()))
+    }
+
+    /// Load TestCommand from a configuration file in the given directory,
+    /// applying the named profile (if any) on top of the base configuration.
+    ///
+    /// `profile` is the name to select; `None` means apply the file's
+    /// `default_profile` if present, else use the base layer alone.
+    pub fn from_directory_with_profile(dir: &Path, profile: Option<&str>) -> Result<Self> {
+        let (cfg, _path) = ConfigFile::find_in_directory(dir)?;
+        let (resolved, _active) = cfg.resolve(profile)?;
+        Ok(TestCommand::new(resolved, dir.to_path_buf()))
     }
 
     /// Execute the test_run_concurrency callout to determine concurrency

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -96,3 +96,202 @@ fn bisect_help_shows_good_and_bad_overrides() {
         "expected positional TEST: {stdout}"
     );
 }
+
+#[test]
+fn config_with_profile_resolves_overlay() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join("inquest.toml"),
+        r#"
+test_command = "echo"
+test_timeout = "1m"
+
+[profiles.ci]
+test_timeout = "5m"
+"#,
+    )
+    .unwrap();
+
+    let out = Command::new(inq_bin())
+        .arg("-C")
+        .arg(temp.path())
+        .arg("--profile")
+        .arg("ci")
+        .arg("config")
+        .output()
+        .expect("run inq --profile ci config");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Active profile: ci"), "got: {stdout}");
+    assert!(
+        stdout.contains("test_timeout: 5m [profile:ci]"),
+        "got: {stdout}"
+    );
+}
+
+#[test]
+fn config_list_profiles_lists_names() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join("inquest.toml"),
+        r#"
+test_command = "echo"
+
+[profiles.ci]
+test_timeout = "5m"
+
+[profiles.nightly]
+test_timeout = "30m"
+"#,
+    )
+    .unwrap();
+
+    let out = Command::new(inq_bin())
+        .arg("-C")
+        .arg(temp.path())
+        .arg("config")
+        .arg("--list-profiles")
+        .output()
+        .expect("run inq config --list-profiles");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Profiles:"), "got: {stdout}");
+    assert!(stdout.contains("  ci"), "got: {stdout}");
+    assert!(stdout.contains("  nightly"), "got: {stdout}");
+}
+
+#[test]
+fn unknown_profile_errors_with_available_list() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join("inquest.toml"),
+        r#"
+test_command = "echo"
+
+[profiles.ci]
+test_timeout = "5m"
+"#,
+    )
+    .unwrap();
+
+    let out = Command::new(inq_bin())
+        .arg("-C")
+        .arg(temp.path())
+        .arg("--profile")
+        .arg("nope")
+        .arg("config")
+        .output()
+        .expect("run inq --profile nope config");
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("nope"), "stderr: {stderr}");
+    assert!(stderr.contains("ci"), "stderr: {stderr}");
+}
+
+#[test]
+fn inq_profile_env_var_selects_profile() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join("inquest.toml"),
+        r#"
+test_command = "echo"
+
+[profiles.ci]
+test_timeout = "5m"
+"#,
+    )
+    .unwrap();
+
+    let out = Command::new(inq_bin())
+        .arg("-C")
+        .arg(temp.path())
+        .arg("config")
+        .env("INQ_PROFILE", "ci")
+        .output()
+        .expect("run inq config with INQ_PROFILE");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Active profile: ci"), "got: {stdout}");
+}
+
+#[test]
+fn cli_profile_overrides_env_var() {
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join("inquest.toml"),
+        r#"
+test_command = "echo"
+
+[profiles.ci]
+test_timeout = "5m"
+
+[profiles.dev]
+test_timeout = "10m"
+"#,
+    )
+    .unwrap();
+
+    let out = Command::new(inq_bin())
+        .arg("-C")
+        .arg(temp.path())
+        .arg("--profile")
+        .arg("dev")
+        .arg("config")
+        .env("INQ_PROFILE", "ci")
+        .output()
+        .expect("run inq --profile dev config");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("Active profile: dev"), "got: {stdout}");
+    assert!(
+        stdout.contains("test_timeout: 10m [profile:dev]"),
+        "got: {stdout}"
+    );
+}
+
+#[test]
+fn flat_config_still_works_unchanged() {
+    // Backwards-compat smoke test: a flat config (no profiles, no
+    // default_profile) loads and resolves with no profile annotations.
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join("inquest.toml"),
+        r#"
+test_command = "cargo subunit $LISTOPT $IDOPTION"
+test_id_option = "--load-list $IDFILE"
+test_list_option = "--list"
+"#,
+    )
+    .unwrap();
+
+    let out = Command::new(inq_bin())
+        .arg("-C")
+        .arg(temp.path())
+        .arg("config")
+        .output()
+        .expect("run inq config");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(!stdout.contains("Active profile:"), "got: {stdout}");
+    assert!(!stdout.contains("[profile:"), "got: {stdout}");
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1383,3 +1383,80 @@ fn test_isolated_run_with_cancellation() {
     );
     assert!(output.any_command_failed);
 }
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore = "sh does not handle Windows paths")]
+fn test_run_with_profile_persists_active_profile_in_metadata() {
+    use inquest::commands::RunCommand;
+    use inquest::repository::inquest::InquestRepositoryFactory;
+
+    let temp = TempDir::new().unwrap();
+    let base_path = temp.path().to_string_lossy().to_string();
+
+    let factory = InquestRepositoryFactory;
+    factory.initialise(temp.path()).unwrap();
+
+    // Base config + a `fast` profile that's the active one for this run.
+    let config = r#"
+test_command = "true"
+
+[profiles.fast]
+test_timeout = "1m"
+"#;
+    fs::write(temp.path().join("inquest.toml"), config).unwrap();
+
+    let load_list_path = temp.path().join("test_ids.txt");
+    fs::write(&load_list_path, "fake_test\n").unwrap();
+
+    let mut ui = TestUI::new();
+    let cmd = RunCommand {
+        base_path: Some(base_path.clone()),
+        load_list: Some(load_list_path.to_string_lossy().to_string()),
+        profile: Some("fast".to_string()),
+        ..Default::default()
+    };
+    let exit_code = cmd.execute(&mut ui).unwrap();
+
+    // Walk the runs and confirm exactly one carries `profile = "fast"`.
+    let repo = factory.open(temp.path()).unwrap();
+    let run_ids = repo.list_run_ids().unwrap();
+    assert_eq!(run_ids.len(), 1);
+    let metadata = repo.get_run_metadata(&run_ids[0]).unwrap();
+    assert_eq!(metadata.profile.as_deref(), Some("fast"));
+    // Sanity: the run actually executed.
+    assert_eq!(metadata.exit_code, Some(exit_code));
+}
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore = "sh does not handle Windows paths")]
+fn test_run_without_profile_records_no_profile_in_metadata() {
+    use inquest::commands::RunCommand;
+    use inquest::repository::inquest::InquestRepositoryFactory;
+
+    let temp = TempDir::new().unwrap();
+    let base_path = temp.path().to_string_lossy().to_string();
+
+    let factory = InquestRepositoryFactory;
+    factory.initialise(temp.path()).unwrap();
+
+    let config = r#"test_command = "true""#;
+    fs::write(temp.path().join("inquest.toml"), config).unwrap();
+
+    let load_list_path = temp.path().join("test_ids.txt");
+    fs::write(&load_list_path, "fake_test\n").unwrap();
+
+    let mut ui = TestUI::new();
+    let cmd = RunCommand {
+        base_path: Some(base_path.clone()),
+        load_list: Some(load_list_path.to_string_lossy().to_string()),
+        profile: None,
+        ..Default::default()
+    };
+    cmd.execute(&mut ui).unwrap();
+
+    let repo = factory.open(temp.path()).unwrap();
+    let run_ids = repo.list_run_ids().unwrap();
+    assert_eq!(run_ids.len(), 1);
+    let metadata = repo.get_run_metadata(&run_ids[0]).unwrap();
+    assert_eq!(metadata.profile, None);
+}


### PR DESCRIPTION
Users can now declare alternative configuration sets under `[profiles.<name>]` and switch between them with `inq --profile NAME`, the `INQ_PROFILE` environment variable, or a `default_profile` field in the config file. Top-level fields remain the implicit base layer, so existing flat configs keep working unchanged. The active profile is recorded in run metadata so `inq info` reports which profile produced a run, and `inq config` annotates each value with its source (cli / profile:NAME / config / default) and gains a `--list-profiles` flag.

Closes #99.