### PR TITLE
Calibrate displayed ETA from prediction-vs-actual history

### DIFF
--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -121,6 +121,7 @@ mod tests {
                 exit_code: Some(1),
                 test_args: None,
                 profile: None,
+                predicted_duration_secs: None,
             },
         )
         .unwrap();
@@ -165,6 +166,7 @@ mod tests {
                 exit_code: Some(0),
                 test_args: None,
                 profile: None,
+                predicted_duration_secs: None,
             },
         )
         .unwrap();

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -107,6 +107,11 @@ pub struct RunCommand {
     /// concurrency-resolution messaging so the user is told how to opt out
     /// of the auto-parallel default. Has no effect on actual concurrency.
     pub implicit_run: bool,
+    /// When true, print details about the ETA prediction: the calibration
+    /// factor and the inputs that produced it (before the run), and the
+    /// predicted-vs-actual comparison (after the run). Wired from the
+    /// global `--eta-debug` CLI flag.
+    pub eta_debug: bool,
 }
 
 impl RunCommand {
@@ -195,6 +200,7 @@ impl RunCommand {
             historical_times,
             filter_tags,
             active_profile.map(|s| s.to_string()),
+            self.eta_debug,
         )?;
         if let Some(buf) = stderr_capture {
             let bytes = match buf.lock() {
@@ -341,6 +347,7 @@ impl RunCommand {
         }
 
         let historical_times = repo.get_test_times().unwrap_or_default();
+        let calibration_samples = crate::eta::load_calibration_samples(repo.as_ref());
         let max_duration_value =
             test_executor::compute_max_duration(&max_duration, &historical_times);
         let test_timeout_fn =
@@ -446,6 +453,28 @@ impl RunCommand {
             suggest_parallel_for_explicit_run(ui, &test_ids, &historical_times)?;
             1
         };
+
+        let calibration_debug =
+            crate::eta::calibration_debug(&calibration_samples, concurrency as u32);
+        let calibration_factor = calibration_debug.factor;
+        if self.eta_debug {
+            for line in crate::eta::format_calibration_debug(&calibration_debug) {
+                ui.output(&line)?;
+            }
+            // `test_ids` is `Some` whenever filtering, ordering, or
+            // `--load-list` resolved a concrete list. When `None`, the
+            // executor will discover; the per-test breakdown isn't worth
+            // the duplicate discovery cost.
+            let known_tests: &[crate::repository::TestId] = test_ids.as_deref().unwrap_or(&[]);
+            for line in crate::eta::format_prediction_debug(
+                known_tests,
+                &historical_times,
+                concurrency as u32,
+                calibration_factor,
+            ) {
+                ui.output(&line)?;
+            }
+        }
 
         if self.isolated {
             let all_tests = if let Some(ids) = test_ids {
@@ -555,6 +584,7 @@ impl RunCommand {
                         test_timeout_fn.as_ref(),
                         run_id,
                         &historical_times,
+                        calibration_factor,
                         || repo.begin_test_run_raw().map(|(_, w)| w),
                     )?
                 } else {
@@ -570,6 +600,7 @@ impl RunCommand {
                         run_id,
                         writer,
                         &historical_times,
+                        calibration_factor,
                     )?
                 };
 
@@ -603,6 +634,7 @@ impl RunCommand {
                 test_timeout_fn.as_ref(),
                 run_id,
                 &historical_times,
+                calibration_factor,
                 || repo.begin_test_run_raw().map(|(_, w)| w),
             )?;
             self.persist(
@@ -627,6 +659,7 @@ impl RunCommand {
                 run_id,
                 writer,
                 &historical_times,
+                calibration_factor,
             )?;
             self.persist(
                 ui,

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -139,6 +139,7 @@ pub fn store_run_metadata(
     exit_code: Option<i32>,
     test_args: Option<Vec<String>>,
     profile: Option<String>,
+    predicted_duration: Option<std::time::Duration>,
 ) -> Result<()> {
     let git_commit = std::process::Command::new("git")
         .args(["rev-parse", "HEAD"])
@@ -175,6 +176,7 @@ pub fn store_run_metadata(
         exit_code,
         test_args,
         profile,
+        predicted_duration_secs: predicted_duration.map(|d| d.as_secs_f64()),
     };
 
     repo.set_run_metadata(run_id, metadata)
@@ -192,6 +194,78 @@ pub fn update_repository_failing_tests(
         repo.replace_failing_tests(test_run)?;
     }
     Ok(())
+}
+
+/// Print a one-line comparison of the run's ETA prediction against its
+/// actual wall-clock duration. The raw historical-sum prediction is
+/// reported alongside its calibrated form (when the calibration factor
+/// differs meaningfully from `1.0`), then the actual duration and the
+/// delta-vs-calibrated-prediction.
+///
+/// Skipped when the raw prediction was zero (no useful signal to
+/// compare against).
+pub fn report_eta_accuracy(
+    ui: &mut dyn UI,
+    predicted: std::time::Duration,
+    actual: std::time::Duration,
+    calibration_factor: f64,
+) -> Result<()> {
+    let predicted_secs = predicted.as_secs_f64();
+    if predicted_secs <= 0.0 {
+        return Ok(());
+    }
+    let calibrated = predicted.mul_f64(calibration_factor);
+    let calibrated_secs = calibrated.as_secs_f64();
+    let actual_secs = actual.as_secs_f64();
+    // Compare against the calibrated prediction — that's what the user
+    // actually saw on-screen during the run.
+    let delta_secs = actual_secs - calibrated_secs;
+    let pct = if calibrated_secs > 0.0 {
+        (delta_secs / calibrated_secs) * 100.0
+    } else {
+        0.0
+    };
+    let direction = if delta_secs >= 0.0 {
+        "slower"
+    } else {
+        "faster"
+    };
+    // Only mention calibration when it materially shifted the prediction;
+    // a no-op factor is just noise.
+    let calibration_note = if (calibration_factor - 1.0).abs() >= 0.05 {
+        format!(
+            ", calibrated {} (×{:.2})",
+            format_short_duration(calibrated),
+            calibration_factor
+        )
+    } else {
+        String::new()
+    };
+    ui.output(&format!(
+        "  ETA accuracy: predicted {}{}, actual {} ({:.0}% {})",
+        format_short_duration(predicted),
+        calibration_note,
+        format_short_duration(actual),
+        pct.abs(),
+        direction,
+    ))?;
+    Ok(())
+}
+
+/// Format a duration as a short human-readable string (e.g., "1m 23s").
+fn format_short_duration(d: std::time::Duration) -> String {
+    let secs = d.as_secs();
+    if secs >= 3600 {
+        let hours = secs / 3600;
+        let mins = (secs % 3600) / 60;
+        format!("{}h {:02}m", hours, mins)
+    } else if secs >= 60 {
+        let mins = secs / 60;
+        let remaining = secs % 60;
+        format!("{}m {:02}s", mins, remaining)
+    } else {
+        format!("{}s", secs)
+    }
 }
 
 /// Display a test run summary, optionally restricting the counts to a tag
@@ -305,6 +379,7 @@ pub fn persist_and_display_run(
     historical_times: &std::collections::HashMap<crate::repository::TestId, std::time::Duration>,
     filter_tags: &[String],
     profile: Option<String>,
+    eta_debug: bool,
 ) -> Result<(i32, RunId)> {
     let exit_code = output.exit_code();
     let crate::test_executor::RunOutput {
@@ -314,6 +389,8 @@ pub fn persist_and_display_run(
         test_command,
         concurrency,
         test_args,
+        predicted_duration,
+        calibration_factor,
         ..
     } = output;
 
@@ -334,9 +411,15 @@ pub fn persist_and_display_run(
         Some(exit_code),
         test_args,
         profile.clone(),
+        predicted_duration,
     )?;
 
     display_test_summary(ui, &run_id, &combined_run, filter_tags)?;
+    if eta_debug {
+        if let Some(predicted) = predicted_duration {
+            report_eta_accuracy(ui, predicted, duration, calibration_factor)?;
+        }
+    }
     warn_slow_tests(ui, &combined_run, historical_times)?;
 
     Ok((exit_code, run_id))
@@ -567,6 +650,183 @@ mod tests {
     }
 
     #[test]
+    fn test_report_eta_accuracy_slower() {
+        let mut ui = crate::ui::test_ui::TestUI::new();
+        report_eta_accuracy(
+            &mut ui,
+            std::time::Duration::from_secs(60),
+            std::time::Duration::from_secs(75),
+            1.0,
+        )
+        .unwrap();
+        assert_eq!(
+            ui.output,
+            vec!["  ETA accuracy: predicted 1m 00s, actual 1m 15s (25% slower)".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_report_eta_accuracy_faster() {
+        let mut ui = crate::ui::test_ui::TestUI::new();
+        report_eta_accuracy(
+            &mut ui,
+            std::time::Duration::from_secs(100),
+            std::time::Duration::from_secs(80),
+            1.0,
+        )
+        .unwrap();
+        assert_eq!(
+            ui.output,
+            vec!["  ETA accuracy: predicted 1m 40s, actual 1m 20s (20% faster)".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_report_eta_accuracy_skips_zero_prediction() {
+        let mut ui = crate::ui::test_ui::TestUI::new();
+        report_eta_accuracy(
+            &mut ui,
+            std::time::Duration::ZERO,
+            std::time::Duration::from_secs(5),
+            1.0,
+        )
+        .unwrap();
+        assert_eq!(ui.output, Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_report_eta_accuracy_with_calibration() {
+        // Predicted 60s raw, calibration ×1.5 → calibrated 90s. Actual 90s.
+        // Delta is computed against the calibrated prediction (what the
+        // user actually saw on-screen), so this lands at 0%.
+        let mut ui = crate::ui::test_ui::TestUI::new();
+        report_eta_accuracy(
+            &mut ui,
+            std::time::Duration::from_secs(60),
+            std::time::Duration::from_secs(90),
+            1.5,
+        )
+        .unwrap();
+        assert_eq!(
+            ui.output,
+            vec![
+                "  ETA accuracy: predicted 1m 00s, calibrated 1m 30s (×1.50), \
+                 actual 1m 30s (0% slower)"
+                    .to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_report_eta_accuracy_calibration_near_one_omits_note() {
+        // A factor of 1.02 isn't worth surfacing — the user would just see
+        // noise. The line drops the calibration clause entirely. The
+        // delta is still measured against the (calibrated) prediction the
+        // user saw — 60s vs 61.2s rounds to 2% faster.
+        let mut ui = crate::ui::test_ui::TestUI::new();
+        report_eta_accuracy(
+            &mut ui,
+            std::time::Duration::from_secs(60),
+            std::time::Duration::from_secs(60),
+            1.02,
+        )
+        .unwrap();
+        assert_eq!(
+            ui.output,
+            vec!["  ETA accuracy: predicted 1m 00s, actual 1m 00s (2% faster)".to_string()]
+        );
+    }
+
+    fn build_run_output_with_prediction(
+        predicted: Option<std::time::Duration>,
+        actual: std::time::Duration,
+    ) -> crate::test_executor::RunOutput {
+        let mut results = std::collections::HashMap::new();
+        results.insert(
+            crate::repository::TestId::new("test1"),
+            crate::repository::TestResult::success("test1").with_duration(actual),
+        );
+        crate::test_executor::RunOutput {
+            run_id: crate::repository::RunId::new("1"),
+            results,
+            any_command_failed: false,
+            duration: actual,
+            test_command: "echo test".to_string(),
+            concurrency: 1,
+            test_args: None,
+            predicted_duration: predicted,
+            calibration_factor: 1.0,
+        }
+    }
+
+    #[test]
+    fn test_persist_omits_eta_accuracy_without_eta_debug() {
+        let temp = TempDir::new().unwrap();
+        let mut repo = init_repository(Some(&temp.path().to_string_lossy())).unwrap();
+        let output = build_run_output_with_prediction(
+            Some(std::time::Duration::from_secs(60)),
+            std::time::Duration::from_secs(75),
+        );
+        let mut ui = crate::ui::test_ui::TestUI::new();
+        let historical = std::collections::HashMap::new();
+        persist_and_display_run(
+            &mut ui,
+            repo.as_mut(),
+            output,
+            false,
+            &historical,
+            &[],
+            None,
+            false,
+        )
+        .unwrap();
+        // Without --eta-debug the summary stops at the pass/fail counts;
+        // the ETA-accuracy line is suppressed.
+        assert_eq!(
+            ui.output,
+            vec![
+                "\nTest run 1:".to_string(),
+                "  Total:   1".to_string(),
+                "  Passed:  1".to_string(),
+                "  Failed:  0".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_persist_includes_eta_accuracy_with_eta_debug() {
+        let temp = TempDir::new().unwrap();
+        let mut repo = init_repository(Some(&temp.path().to_string_lossy())).unwrap();
+        let output = build_run_output_with_prediction(
+            Some(std::time::Duration::from_secs(60)),
+            std::time::Duration::from_secs(75),
+        );
+        let mut ui = crate::ui::test_ui::TestUI::new();
+        let historical = std::collections::HashMap::new();
+        persist_and_display_run(
+            &mut ui,
+            repo.as_mut(),
+            output,
+            false,
+            &historical,
+            &[],
+            None,
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            ui.output,
+            vec![
+                "\nTest run 1:".to_string(),
+                "  Total:   1".to_string(),
+                "  Passed:  1".to_string(),
+                "  Failed:  0".to_string(),
+                "  ETA accuracy: predicted 1m 00s, actual 1m 15s (25% slower)".to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn test_persist_and_display_run_success() {
         let temp = TempDir::new().unwrap();
         let mut repo = init_repository(Some(&temp.path().to_string_lossy())).unwrap();
@@ -592,6 +852,8 @@ mod tests {
             test_command: "echo test".to_string(),
             concurrency: 1,
             test_args: None,
+            predicted_duration: None,
+            calibration_factor: 1.0,
         };
 
         let mut ui = crate::ui::test_ui::TestUI::new();
@@ -604,6 +866,7 @@ mod tests {
             &historical,
             &[],
             None,
+            false,
         )
         .unwrap();
 
@@ -681,6 +944,8 @@ mod tests {
             test_command: "cargo test".to_string(),
             concurrency: 1,
             test_args: None,
+            predicted_duration: None,
+            calibration_factor: 1.0,
         };
 
         let mut ui = crate::ui::test_ui::TestUI::new();
@@ -693,6 +958,7 @@ mod tests {
             &historical,
             &[],
             None,
+            false,
         )
         .unwrap();
 

--- a/src/eta.rs
+++ b/src/eta.rs
@@ -1,15 +1,38 @@
 //! ETA computation for the test-runner progress bar.
 //!
-//! The display has two halves: an [`EtaModel`] that resolves a per-test
+//! The display has three halves: an [`EtaModel`] that resolves a per-test
 //! historical duration (with a mean fallback for tests that have no recorded
-//! history), and an [`EtaState`] that aggregates progress across one or more
+//! history), an [`EtaState`] that aggregates progress across one or more
 //! workers and renders the formatted ETA string for indicatif's `{eta_hist}`
-//! template key.
+//! template key, and a calibration helper that learns a multiplicative
+//! correction from past `(predicted, actual)` pairs so the displayed ETA
+//! accounts for systematic biases (parallel overhead, discovery time, etc.).
 
-use crate::repository::TestId;
+use crate::repository::{Repository, RunId, TestId};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+/// How many recent runs to inspect when computing the calibration factor.
+/// Older runs are ignored entirely; bounding the lookback keeps the factor
+/// responsive to environment changes (CI host swap, machine upgrade, …).
+const CALIBRATION_LOOKBACK: usize = 20;
+
+/// Minimum number of usable samples in the lookback window before we apply
+/// any correction. Below this threshold a single anomalous run would
+/// dominate, so we fall back to the raw historical-sum prediction.
+const CALIBRATION_MIN_SAMPLES: usize = 3;
+
+/// EWMA decay coefficient. `α = 0.3` weights the most recent sample at 30%
+/// and decays older samples geometrically — recent enough to react to a
+/// regression, smooth enough to ignore one-off noise.
+const CALIBRATION_ALPHA: f64 = 0.3;
+
+/// Clamp range for the resulting factor. A factor outside this range is
+/// almost always a bug or a degenerate prediction (e.g. predicted ≈ 0 due
+/// to missing history) rather than a real signal worth honouring.
+const CALIBRATION_MIN: f64 = 0.25;
+const CALIBRATION_MAX: f64 = 4.0;
 
 /// Resolves a per-test estimated duration, falling back to the mean of known
 /// durations for tests that have no recorded history. This keeps
@@ -246,6 +269,241 @@ impl EtaState {
     }
 }
 
+/// One observation of a past run's predicted-vs-actual duration, narrowed to
+/// the fields the calibration math actually uses.
+#[derive(Debug, Clone, Copy)]
+pub struct CalibrationSample {
+    /// Concurrency the run executed at. Used as the bucket key — a parallel
+    /// run's overhead profile differs sharply from a serial run's, so they
+    /// must not feed the same factor.
+    pub concurrency: u32,
+    /// Wall-clock prediction recorded at run start (before calibration).
+    pub predicted_secs: f64,
+    /// Wall-clock duration the run actually took.
+    pub actual_secs: f64,
+}
+
+/// Compute a multiplicative correction for the raw historical-sum prediction
+/// at the given concurrency, derived from the most recent
+/// [`CALIBRATION_LOOKBACK`] runs at that same concurrency.
+///
+/// Returns `1.0` (i.e. "no correction") when fewer than
+/// [`CALIBRATION_MIN_SAMPLES`] usable samples are available — one or two
+/// runs is too little signal to override a known prediction with.
+///
+/// `samples` is expected in chronological order (oldest first); the EWMA
+/// weights the most recent sample most heavily.
+pub fn calibration_factor(samples: &[CalibrationSample], concurrency: u32) -> f64 {
+    let bucket: Vec<f64> = samples
+        .iter()
+        .filter(|s| s.concurrency == concurrency)
+        .filter(|s| s.predicted_secs > 0.0 && s.actual_secs > 0.0)
+        .rev()
+        .take(CALIBRATION_LOOKBACK)
+        .map(|s| s.actual_secs / s.predicted_secs)
+        .collect();
+
+    if bucket.len() < CALIBRATION_MIN_SAMPLES {
+        return 1.0;
+    }
+
+    // `bucket` is newest-first; walk oldest-first to apply EWMA, so the
+    // newest sample lands with full α weight at the end.
+    let mut ewma: Option<f64> = None;
+    for ratio in bucket.iter().rev() {
+        ewma = Some(match ewma {
+            None => *ratio,
+            Some(prev) => CALIBRATION_ALPHA * ratio + (1.0 - CALIBRATION_ALPHA) * prev,
+        });
+    }
+    ewma.unwrap_or(1.0).clamp(CALIBRATION_MIN, CALIBRATION_MAX)
+}
+
+/// Why a calibration factor took the value it did. Built alongside the
+/// factor for `--debug` output so the user can see why the displayed ETA
+/// is (or isn't) being adjusted.
+#[derive(Debug, Clone)]
+pub struct CalibrationDebug {
+    /// Total samples loaded across all concurrencies.
+    pub total_samples: usize,
+    /// Samples that matched this run's concurrency and had usable values.
+    /// Only samples within the lookback window count.
+    pub bucket_samples: usize,
+    /// Concurrency used as the bucket key.
+    pub concurrency: u32,
+    /// Final calibration factor (clamped). `1.0` when the bucket was below
+    /// the minimum-samples threshold or the EWMA saturated against the
+    /// configured clamp.
+    pub factor: f64,
+    /// Most recent (oldest-first) `actual / predicted` ratios that fed the
+    /// EWMA. Capped at [`CALIBRATION_LOOKBACK`].
+    pub recent_ratios: Vec<f64>,
+    /// Minimum samples needed before any correction is applied.
+    pub min_samples: usize,
+}
+
+/// Compute the calibration factor *and* a structured trace of how it was
+/// derived. Equivalent to [`calibration_factor`] but with the inputs and
+/// intermediate values surfaced for debug output.
+pub fn calibration_debug(samples: &[CalibrationSample], concurrency: u32) -> CalibrationDebug {
+    let bucket: Vec<f64> = samples
+        .iter()
+        .filter(|s| s.concurrency == concurrency)
+        .filter(|s| s.predicted_secs > 0.0 && s.actual_secs > 0.0)
+        .rev()
+        .take(CALIBRATION_LOOKBACK)
+        .map(|s| s.actual_secs / s.predicted_secs)
+        .collect();
+
+    // Restore chronological (oldest-first) order for display and EWMA.
+    let mut recent_ratios = bucket;
+    recent_ratios.reverse();
+
+    let factor = calibration_factor(samples, concurrency);
+    CalibrationDebug {
+        total_samples: samples.len(),
+        bucket_samples: recent_ratios.len(),
+        concurrency,
+        factor,
+        recent_ratios,
+        min_samples: CALIBRATION_MIN_SAMPLES,
+    }
+}
+
+/// Render a one-block summary of how the displayed wall-clock ETA was
+/// derived: how many tests have history, the raw historical sum, the
+/// concurrency divisor (for parallel runs), and the final calibrated
+/// number the user will see decay on the progress bar.
+///
+/// `tests` is the resolved test list; pass an empty slice to skip the
+/// per-test counts (e.g. when discovery-driven, the executor will compute
+/// these itself and the caller can't pre-empt them cheaply).
+pub fn format_prediction_debug(
+    tests: &[TestId],
+    historical_times: &HashMap<TestId, Duration>,
+    concurrency: u32,
+    calibration_factor: f64,
+) -> Vec<String> {
+    if tests.is_empty() {
+        return vec![
+            "ETA debug: prediction breakdown unavailable (tests will be \
+                     discovered by the runner)."
+                .to_string(),
+        ];
+    }
+    let known: usize = tests
+        .iter()
+        .filter(|t| historical_times.contains_key(*t))
+        .count();
+    let unknown = tests.len().saturating_sub(known);
+    let restricted: HashMap<TestId, Duration> = historical_times
+        .iter()
+        .filter(|(id, _)| tests.iter().any(|t| t == *id))
+        .map(|(id, d)| (id.clone(), *d))
+        .collect();
+    let model = EtaModel::new(Arc::new(restricted));
+    let raw_total = model.estimated_total(tests.iter());
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "ETA debug: {} test(s) selected — {} with history, {} new (mean fallback {}).",
+        tests.len(),
+        known,
+        unknown,
+        format_duration_short(model.mean_known.unwrap_or(Duration::ZERO)),
+    ));
+    let serial_eq = format_duration_short(raw_total);
+    if concurrency > 1 {
+        let per_worker = raw_total / concurrency;
+        let calibrated = per_worker.mul_f64(calibration_factor);
+        lines.push(format!(
+            "  Raw sequential estimate: {} → {}-way parallel: {} → calibrated (×{:.2}): {}",
+            serial_eq,
+            concurrency,
+            format_duration_short(per_worker),
+            calibration_factor,
+            format_duration_short(calibrated),
+        ));
+    } else {
+        let calibrated = raw_total.mul_f64(calibration_factor);
+        lines.push(format!(
+            "  Raw estimate: {} → calibrated (×{:.2}): {}",
+            serial_eq,
+            calibration_factor,
+            format_duration_short(calibrated),
+        ));
+    }
+    lines
+}
+
+/// Render the calibration debug as the lines to print under `--debug`.
+/// Lines come without a leading newline so the caller can decide framing.
+pub fn format_calibration_debug(debug: &CalibrationDebug) -> Vec<String> {
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "ETA debug: {} sample(s) total, {} at concurrency={} (need ≥{}).",
+        debug.total_samples, debug.bucket_samples, debug.concurrency, debug.min_samples,
+    ));
+    if debug.bucket_samples < debug.min_samples {
+        lines.push(format!(
+            "  Calibration factor: {:.2} (too few samples — using raw historical sum).",
+            debug.factor,
+        ));
+    } else {
+        lines.push(format!(
+            "  Calibration factor: {:.2} (EWMA α={}, clamp [{:.2}, {:.2}]).",
+            debug.factor, CALIBRATION_ALPHA, CALIBRATION_MIN, CALIBRATION_MAX,
+        ));
+    }
+    if !debug.recent_ratios.is_empty() {
+        let formatted: Vec<String> = debug
+            .recent_ratios
+            .iter()
+            .map(|r| format!("{:.2}", r))
+            .collect();
+        lines.push(format!(
+            "  Recent actual/predicted ratios (oldest→newest): [{}]",
+            formatted.join(", "),
+        ));
+    }
+    lines
+}
+
+/// Load calibration samples from the repository's recent runs. Pulls only
+/// what `calibration_factor` will actually consume — the most recent
+/// `CALIBRATION_LOOKBACK × 4` runs across all concurrencies, so a busy
+/// repo with many small concurrencies still gets enough samples in any one
+/// bucket. Reads are best-effort: a missing or malformed run is silently
+/// skipped, since calibration is an optimisation rather than a correctness
+/// requirement.
+pub fn load_calibration_samples(repo: &dyn Repository) -> Vec<CalibrationSample> {
+    let Ok(ids) = repo.list_run_ids() else {
+        return Vec::new();
+    };
+    let scan_limit = CALIBRATION_LOOKBACK.saturating_mul(4);
+    let recent_ids: Vec<&RunId> = ids.iter().rev().take(scan_limit).collect();
+
+    let mut samples: Vec<CalibrationSample> = Vec::with_capacity(recent_ids.len());
+    // Walk oldest-first within the recent window so the EWMA sees newest last.
+    for id in recent_ids.iter().rev() {
+        let Ok(meta) = repo.get_run_metadata(id) else {
+            continue;
+        };
+        let (Some(predicted_secs), Some(actual_secs), Some(concurrency)) = (
+            meta.predicted_duration_secs,
+            meta.duration_secs,
+            meta.concurrency,
+        ) else {
+            continue;
+        };
+        samples.push(CalibrationSample {
+            concurrency,
+            predicted_secs,
+            actual_secs,
+        });
+    }
+    samples
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -457,5 +715,267 @@ mod tests {
         // completed + in-flight credit.
         let rendered = state.render();
         assert!(rendered.starts_with(" ETA: "), "got: {:?}", rendered);
+    }
+
+    fn sample(concurrency: u32, predicted: f64, actual: f64) -> CalibrationSample {
+        CalibrationSample {
+            concurrency,
+            predicted_secs: predicted,
+            actual_secs: actual,
+        }
+    }
+
+    #[test]
+    fn calibration_returns_neutral_with_too_few_samples() {
+        let samples = vec![sample(4, 60.0, 90.0), sample(4, 60.0, 90.0)];
+        assert_eq!(calibration_factor(&samples, 4), 1.0);
+    }
+
+    #[test]
+    fn calibration_filters_to_matching_concurrency() {
+        let samples = vec![
+            sample(1, 60.0, 90.0),
+            sample(1, 60.0, 90.0),
+            sample(1, 60.0, 90.0),
+            sample(4, 60.0, 30.0),
+        ];
+        // Only one sample at concurrency=4 — too few, so factor is 1.0.
+        assert_eq!(calibration_factor(&samples, 4), 1.0);
+        // Three samples at concurrency=1 with ratio 1.5 — factor should
+        // converge there (EWMA on a constant series collapses to that value).
+        let f = calibration_factor(&samples, 1);
+        assert!((f - 1.5).abs() < 1e-9, "got {}", f);
+    }
+
+    #[test]
+    fn calibration_skips_zero_or_negative_predictions() {
+        let samples = vec![
+            sample(2, 0.0, 90.0),  // predicted=0: skipped
+            sample(2, 60.0, 0.0),  // actual=0: skipped
+            sample(2, -1.0, 50.0), // negative: skipped
+            sample(2, 60.0, 60.0),
+            sample(2, 60.0, 60.0),
+        ];
+        // Only two valid samples — below threshold, so 1.0.
+        assert_eq!(calibration_factor(&samples, 2), 1.0);
+    }
+
+    #[test]
+    fn calibration_weights_recent_samples_more() {
+        // Old runs were 2x slower than predicted, recent runs are accurate.
+        // EWMA should land closer to 1.0 than to 2.0.
+        let samples = vec![
+            sample(4, 60.0, 120.0), // ratio 2.0
+            sample(4, 60.0, 120.0), // 2.0
+            sample(4, 60.0, 120.0), // 2.0
+            sample(4, 60.0, 60.0),  // 1.0
+            sample(4, 60.0, 60.0),  // 1.0
+            sample(4, 60.0, 60.0),  // 1.0
+        ];
+        let f = calibration_factor(&samples, 4);
+        // Closer to recent (1.0) than to old (2.0).
+        assert!(f < 1.4, "expected EWMA < 1.4, got {}", f);
+        assert!(f > 1.0, "expected EWMA > 1.0, got {}", f);
+    }
+
+    #[test]
+    fn calibration_clamps_outliers() {
+        // A pathological 100x slowdown should still be bounded.
+        let samples = vec![
+            sample(2, 1.0, 100.0),
+            sample(2, 1.0, 100.0),
+            sample(2, 1.0, 100.0),
+        ];
+        let f = calibration_factor(&samples, 2);
+        assert_eq!(f, CALIBRATION_MAX);
+    }
+
+    #[test]
+    fn calibration_clamps_underestimate_outliers() {
+        let samples = vec![
+            sample(2, 100.0, 1.0),
+            sample(2, 100.0, 1.0),
+            sample(2, 100.0, 1.0),
+        ];
+        let f = calibration_factor(&samples, 2);
+        assert_eq!(f, CALIBRATION_MIN);
+    }
+
+    #[test]
+    fn load_calibration_samples_pulls_runs_with_full_metadata() {
+        use crate::repository::{
+            inquest::InquestRepositoryFactory, RepositoryFactory, RunMetadata, TestResult, TestRun,
+        };
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let mut repo = InquestRepositoryFactory.initialise(temp.path()).unwrap();
+
+        let mut run0 = TestRun::new(RunId::new("0"));
+        run0.timestamp = chrono::DateTime::from_timestamp(1_000_000_000, 0).unwrap();
+        run0.add_result(TestResult::success("a"));
+        let id0 = repo.insert_test_run(run0).unwrap();
+        repo.set_run_metadata(
+            &id0,
+            RunMetadata {
+                concurrency: Some(2),
+                duration_secs: Some(45.0),
+                predicted_duration_secs: Some(30.0),
+                ..RunMetadata::default()
+            },
+        )
+        .unwrap();
+
+        // A run missing predicted_duration — should be skipped silently.
+        let mut run1 = TestRun::new(RunId::new("1"));
+        run1.timestamp = chrono::DateTime::from_timestamp(1_000_000_001, 0).unwrap();
+        run1.add_result(TestResult::success("a"));
+        let id1 = repo.insert_test_run(run1).unwrap();
+        repo.set_run_metadata(
+            &id1,
+            RunMetadata {
+                concurrency: Some(2),
+                duration_secs: Some(20.0),
+                predicted_duration_secs: None,
+                ..RunMetadata::default()
+            },
+        )
+        .unwrap();
+
+        let samples = load_calibration_samples(repo.as_ref());
+        assert_eq!(samples.len(), 1, "got: {:?}", samples);
+        assert_eq!(samples[0].concurrency, 2);
+        assert!((samples[0].predicted_secs - 30.0).abs() < 1e-9);
+        assert!((samples[0].actual_secs - 45.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn calibration_lookback_caps_history_window() {
+        // Many old "1.0" runs followed by a few recent "2.0" runs. With
+        // CALIBRATION_LOOKBACK=20 the recent runs dominate completely once
+        // there are enough; if the cap weren't applied, the long tail of
+        // 1.0s would pull the EWMA down further than it should.
+        let mut samples = Vec::new();
+        for _ in 0..50 {
+            samples.push(sample(1, 10.0, 10.0)); // ratio 1.0
+        }
+        for _ in 0..10 {
+            samples.push(sample(1, 10.0, 20.0)); // ratio 2.0
+        }
+        let f = calibration_factor(&samples, 1);
+        // With the cap, only the last 20 samples count: 10 of ratio 1.0 then
+        // 10 of ratio 2.0. Without the cap, it'd be ~1.0. Verify we're at
+        // least clearly above 1.0.
+        assert!(
+            f > 1.5,
+            "expected factor > 1.5 with lookback cap, got {}",
+            f
+        );
+    }
+
+    #[test]
+    fn format_calibration_debug_too_few_samples() {
+        let samples = vec![sample(4, 60.0, 90.0), sample(4, 60.0, 90.0)];
+        let debug = calibration_debug(&samples, 4);
+        let lines = format_calibration_debug(&debug);
+        assert_eq!(
+            lines,
+            vec![
+                "ETA debug: 2 sample(s) total, 2 at concurrency=4 (need ≥3).".to_string(),
+                "  Calibration factor: 1.00 (too few samples — using raw historical sum)."
+                    .to_string(),
+                "  Recent actual/predicted ratios (oldest→newest): [1.50, 1.50]".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn format_calibration_debug_with_factor() {
+        let samples = vec![
+            sample(2, 60.0, 90.0),
+            sample(2, 60.0, 90.0),
+            sample(2, 60.0, 90.0),
+        ];
+        let debug = calibration_debug(&samples, 2);
+        let lines = format_calibration_debug(&debug);
+        assert_eq!(
+            lines,
+            vec![
+                "ETA debug: 3 sample(s) total, 3 at concurrency=2 (need ≥3).".to_string(),
+                "  Calibration factor: 1.50 (EWMA α=0.3, clamp [0.25, 4.00]).".to_string(),
+                "  Recent actual/predicted ratios (oldest→newest): [1.50, 1.50, 1.50]".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn format_calibration_debug_no_samples() {
+        let debug = calibration_debug(&[], 4);
+        let lines = format_calibration_debug(&debug);
+        assert_eq!(
+            lines,
+            vec![
+                "ETA debug: 0 sample(s) total, 0 at concurrency=4 (need ≥3).".to_string(),
+                "  Calibration factor: 1.00 (too few samples — using raw historical sum)."
+                    .to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn format_prediction_debug_serial() {
+        let mut historical = HashMap::new();
+        historical.insert(TestId::new("a"), Duration::from_secs(10));
+        historical.insert(TestId::new("b"), Duration::from_secs(20));
+        let tests = vec![TestId::new("a"), TestId::new("b"), TestId::new("c")];
+        let lines = format_prediction_debug(&tests, &historical, 1, 1.0);
+        // Known: a, b. Unknown: c → mean fallback 15s. Total 10+20+15 = 45s.
+        assert_eq!(
+            lines,
+            vec![
+                "ETA debug: 3 test(s) selected — 2 with history, 1 new (mean fallback 15s)."
+                    .to_string(),
+                "  Raw estimate: 45s → calibrated (×1.00): 45s".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn format_prediction_debug_parallel_with_calibration() {
+        let mut historical = HashMap::new();
+        historical.insert(TestId::new("a"), Duration::from_secs(60));
+        historical.insert(TestId::new("b"), Duration::from_secs(60));
+        historical.insert(TestId::new("c"), Duration::from_secs(60));
+        historical.insert(TestId::new("d"), Duration::from_secs(60));
+        let tests = vec![
+            TestId::new("a"),
+            TestId::new("b"),
+            TestId::new("c"),
+            TestId::new("d"),
+        ];
+        let lines = format_prediction_debug(&tests, &historical, 4, 1.5);
+        // Raw 4×60 = 240s. /4 = 60s. ×1.5 = 90s.
+        assert_eq!(
+            lines,
+            vec![
+                "ETA debug: 4 test(s) selected — 4 with history, 0 new (mean fallback 1m 00s)."
+                    .to_string(),
+                "  Raw sequential estimate: 4m 00s → 4-way parallel: 1m 00s → calibrated \
+                 (×1.50): 1m 30s"
+                    .to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn format_prediction_debug_unknown_tests() {
+        let lines = format_prediction_debug(&[], &HashMap::new(), 2, 1.0);
+        assert_eq!(
+            lines,
+            vec![
+                "ETA debug: prediction breakdown unavailable (tests will be discovered \
+                 by the runner)."
+                    .to_string()
+            ]
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,11 @@ struct Cli {
     #[arg(long, global = true, value_name = "NAME")]
     profile: Option<String>,
 
+    /// Print details about the ETA prediction (calibration factor,
+    /// per-test breakdown, predicted-vs-actual accuracy after the run).
+    #[arg(long = "eta-debug", global = true)]
+    eta_debug: bool,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -785,6 +790,7 @@ fn main() {
                 test_ids_override: None,
                 profile: profile.clone(),
                 implicit_run,
+                eta_debug: cli.eta_debug,
             };
             cmd.execute(&mut ui)
         }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1568,6 +1568,7 @@ impl InquestMcpService {
             })?;
 
             let historical_times = repo.get_test_times().map_err(to_mcp_err)?;
+            let calibration_samples = crate::eta::load_calibration_samples(repo.as_ref());
 
             // Resolve test IDs before spawning (needs repo)
             let mut test_ids = if failing_only {
@@ -1616,6 +1617,8 @@ impl InquestMcpService {
             }
 
             let concurrency = params.concurrency.unwrap_or(1);
+            let calibration_factor =
+                crate::eta::calibration_factor(&calibration_samples, concurrency as u32);
 
             // Pre-allocate the run — this creates the lock file so inq_running sees it
             let (run_id, writer) = repo.begin_test_run_raw().map_err(to_mcp_err)?;
@@ -1658,6 +1661,7 @@ impl InquestMcpService {
                         None,
                         run_id,
                         &historical_times,
+                        calibration_factor,
                         || {
                             let mut repo = crate::commands::utils::open_repository(Some(&dir))?;
                             repo.begin_test_run_raw().map(|(_, w)| w)
@@ -1674,6 +1678,7 @@ impl InquestMcpService {
                         run_id,
                         writer,
                         &historical_times,
+                        calibration_factor,
                     )
                 };
 
@@ -1689,6 +1694,7 @@ impl InquestMcpService {
                                     &historical_times,
                                     &[],
                                     None,
+                                    false,
                                 ) {
                                     tracing::error!(
                                         "Failed to persist background run results: {}",
@@ -2566,6 +2572,7 @@ mod tests {
                 exit_code: Some(1),
                 test_args: None,
                 profile: None,
+                predicted_duration_secs: None,
             },
         )
         .unwrap();

--- a/src/repository/inquest.rs
+++ b/src/repository/inquest.rs
@@ -166,7 +166,8 @@ fn create_schema(conn: &rusqlite::Connection) -> Result<()> {
             errors INTEGER NOT NULL DEFAULT 0,
             skips INTEGER NOT NULL DEFAULT 0,
             test_args TEXT,
-            profile TEXT
+            profile TEXT,
+            predicted_duration_secs REAL
         );
 
         CREATE TABLE test_results (
@@ -231,6 +232,7 @@ fn migrate_schema(conn: &rusqlite::Connection) -> Result<()> {
     add_column_if_missing(conn, "runs", "git_dirty", "INTEGER");
     add_column_if_missing(conn, "runs", "test_args", "TEXT");
     add_column_if_missing(conn, "runs", "profile", "TEXT");
+    add_column_if_missing(conn, "runs", "predicted_duration_secs", "REAL");
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS test_results_test_id_run_id \
          ON test_results (test_id, run_id);
@@ -680,7 +682,7 @@ impl Repository for InquestRepository {
 
     fn get_run_metadata(&self, run_id: &RunId) -> Result<RunMetadata> {
         let result = self.conn.query_row(
-            "SELECT git_commit, git_dirty, command, concurrency, duration_secs, exit_code, test_args, profile FROM runs WHERE id = ?",
+            "SELECT git_commit, git_dirty, command, concurrency, duration_secs, exit_code, test_args, profile, predicted_duration_secs FROM runs WHERE id = ?",
             [run_id.as_str()],
             |row| {
                 let test_args_json: Option<String> = row.get(6)?;
@@ -696,6 +698,7 @@ impl Repository for InquestRepository {
                     exit_code: row.get(5)?,
                     test_args,
                     profile: row.get(7)?,
+                    predicted_duration_secs: row.get(8)?,
                 })
             },
         );
@@ -826,7 +829,7 @@ impl Repository for InquestRepository {
             .transpose()
             .map_err(|e| Error::Other(format!("Failed to serialize test_args: {}", e)))?;
         self.conn.execute(
-            "UPDATE runs SET git_commit = ?, git_dirty = ?, command = ?, concurrency = ?, duration_secs = ?, exit_code = ?, test_args = ?, profile = ? WHERE id = ?",
+            "UPDATE runs SET git_commit = ?, git_dirty = ?, command = ?, concurrency = ?, duration_secs = ?, exit_code = ?, test_args = ?, profile = ?, predicted_duration_secs = ? WHERE id = ?",
             params![
                 metadata.git_commit,
                 metadata.git_dirty,
@@ -836,6 +839,7 @@ impl Repository for InquestRepository {
                 metadata.exit_code,
                 test_args_json,
                 metadata.profile,
+                metadata.predicted_duration_secs,
                 run_id.as_str(),
             ],
         )?;
@@ -1459,6 +1463,7 @@ mod tests {
                 exit_code: Some(1),
                 test_args: Some(vec!["-x".to_string(), "--maxfail=3".to_string()]),
                 profile: None,
+                predicted_duration_secs: None,
             },
         )
         .unwrap();
@@ -1720,6 +1725,7 @@ mod tests {
                 exit_code: Some(0),
                 test_args: None,
                 profile: None,
+                predicted_duration_secs: None,
             },
         )
         .unwrap();

--- a/src/repository/test_run.rs
+++ b/src/repository/test_run.rs
@@ -348,6 +348,12 @@ pub struct RunMetadata {
     /// `default_profile`, when one was applied. `None` for runs that used
     /// the base layer alone, including all runs predating profile support.
     pub profile: Option<String>,
+    /// Wall-clock duration the run was *predicted* to take, in seconds,
+    /// based on historical per-test times alone (i.e. before any
+    /// calibration adjustment). Used to compute a per-bucket calibration
+    /// factor for future runs. `None` when no historical signal was
+    /// available, or for runs predating ETA-accuracy tracking.
+    pub predicted_duration_secs: Option<f64>,
 }
 
 /// A complete test run containing results for multiple tests.

--- a/src/test_executor.rs
+++ b/src/test_executor.rs
@@ -53,6 +53,19 @@ pub struct RunOutput {
     /// Extra arguments forwarded to the test command after `--`. Captured so
     /// `inq rerun` can reproduce the original invocation.
     pub test_args: Option<Vec<String>>,
+    /// Wall-clock duration predicted from historical times before the run
+    /// started, if any history was available. This is the *raw* prediction
+    /// (sum of historical per-test times divided by concurrency); the
+    /// calibration factor is reported separately as
+    /// [`Self::calibration_factor`]. Persisted as-is so future runs
+    /// calibrate against an honest baseline.
+    /// `None` when there was no historical signal to base a prediction on.
+    pub predicted_duration: Option<Duration>,
+    /// Multiplicative correction applied on top of `predicted_duration`
+    /// when computing the *displayed* ETA. `1.0` when no calibration was
+    /// applied (insufficient history, or the run had no
+    /// `predicted_duration` to scale).
+    pub calibration_factor: f64,
 }
 
 impl RunOutput {
@@ -301,6 +314,8 @@ impl<'a> TestExecutor<'a> {
             test_command: test_cmd.config().test_command.clone(),
             concurrency: 1,
             test_args: self.config.test_args.clone(),
+            predicted_duration: None,
+            calibration_factor: 1.0,
         })
     }
 
@@ -308,6 +323,12 @@ impl<'a> TestExecutor<'a> {
     ///
     /// The caller must pre-allocate the run via `repo.begin_test_run_raw()` and
     /// pass the resulting `(run_id, writer)`.
+    ///
+    /// `calibration_factor` scales the displayed ETA by a learned correction
+    /// factor (typically derived from past predicted-vs-actual deltas). The
+    /// factor only changes what's *shown* — the raw historical-sum
+    /// prediction is still recorded into the returned [`RunOutput`] so
+    /// future calibration math sees an unbiased baseline.
     #[allow(clippy::too_many_arguments)]
     pub fn run_serial(
         &self,
@@ -320,6 +341,7 @@ impl<'a> TestExecutor<'a> {
         run_id: RunId,
         raw_writer: Box<dyn std::io::Write + Send>,
         historical_times: &HashMap<TestId, Duration>,
+        calibration_factor: f64,
     ) -> Result<RunOutput> {
         let mut remaining_tests: Option<Vec<TestId>> = test_ids.map(|ids| ids.to_vec());
         let mut all_results: HashMap<TestId, TestResult> = HashMap::new();
@@ -350,6 +372,7 @@ impl<'a> TestExecutor<'a> {
         );
         let eta_model = EtaModel::new(durations);
         let estimated_total: Duration = eta_model.estimated_total(known_tests);
+        let calibrated_total = estimated_total.mul_f64(calibration_factor);
 
         let start_time = std::time::Instant::now();
         let mut next_raw_writer: Option<Box<dyn std::io::Write + Send>> = Some(raw_writer);
@@ -360,7 +383,7 @@ impl<'a> TestExecutor<'a> {
         let max_msg_len = layout.max_msg_len;
 
         let eta_state = if eta_model.has_history() {
-            Some(EtaState::new(estimated_total))
+            Some(EtaState::new(calibrated_total))
         } else {
             None
         };
@@ -670,6 +693,8 @@ impl<'a> TestExecutor<'a> {
             test_command: test_cmd.config().test_command.clone(),
             concurrency: 1,
             test_args: self.config.test_args.clone(),
+            predicted_duration: eta_model.has_history().then_some(estimated_total),
+            calibration_factor,
         })
     }
 
@@ -678,6 +703,10 @@ impl<'a> TestExecutor<'a> {
     /// The caller must pre-allocate `run_id` (e.g. via `repo.get_next_run_id()`).
     /// The `writer_factory` closure is called to create a writer for each worker on the
     /// first iteration; on restart iterations, workers write to `io::sink()`.
+    ///
+    /// `calibration_factor` scales the *displayed* ETA only; the raw
+    /// historical-sum prediction is still recorded in the returned
+    /// [`RunOutput`] so future calibration math has an unbiased baseline.
     #[allow(clippy::too_many_arguments)]
     pub fn run_parallel<F>(
         &self,
@@ -690,6 +719,7 @@ impl<'a> TestExecutor<'a> {
         test_timeout_fn: Option<&TestTimeoutFn>,
         run_id: RunId,
         historical_times: &HashMap<TestId, Duration>,
+        calibration_factor: f64,
         mut writer_factory: F,
     ) -> Result<RunOutput>
     where
@@ -717,6 +747,8 @@ impl<'a> TestExecutor<'a> {
                 test_command: test_cmd.config().test_command.clone(),
                 concurrency: concurrency as u32,
                 test_args: self.config.test_args.clone(),
+                predicted_duration: None,
+                calibration_factor: 1.0,
             });
         }
 
@@ -730,6 +762,7 @@ impl<'a> TestExecutor<'a> {
         );
         let eta_model = EtaModel::new(Arc::clone(&durations));
         let overall_estimated_total: Duration = eta_model.estimated_total(all_tests.iter());
+        let calibrated_overall_total = overall_estimated_total.mul_f64(calibration_factor);
 
         let group_regex = test_cmd.config().group_regex.as_deref();
 
@@ -746,7 +779,7 @@ impl<'a> TestExecutor<'a> {
         let overall_bar_width = overall_layout.bar_width;
 
         let overall_eta_state = if eta_model.has_history() {
-            Some(EtaState::new(overall_estimated_total))
+            Some(EtaState::new(calibrated_overall_total))
         } else {
             None
         };
@@ -816,7 +849,9 @@ impl<'a> TestExecutor<'a> {
                 // total would over-estimate.
                 let worker_estimated_total = eta_model.estimated_total(partition.iter());
                 let worker_eta_state = if eta_model.has_history() {
-                    Some(EtaState::new(worker_estimated_total))
+                    Some(EtaState::new(
+                        worker_estimated_total.mul_f64(calibration_factor),
+                    ))
                 } else {
                     None
                 };
@@ -1053,6 +1088,10 @@ impl<'a> TestExecutor<'a> {
             test_command: test_cmd.config().test_command.clone(),
             concurrency: concurrency as u32,
             test_args: self.config.test_args.clone(),
+            predicted_duration: eta_model
+                .has_history()
+                .then(|| overall_estimated_total / concurrency as u32),
+            calibration_factor,
         })
     }
 
@@ -1226,6 +1265,8 @@ impl<'a> TestExecutor<'a> {
             test_command: test_cmd.config().test_command.clone(),
             concurrency: 1,
             test_args: self.config.test_args.clone(),
+            predicted_duration: None,
+            calibration_factor: 1.0,
         })
     }
 }
@@ -1896,6 +1937,8 @@ mod tests {
             test_command: "echo".to_string(),
             concurrency: 1,
             test_args: None,
+            predicted_duration: None,
+            calibration_factor: 1.0,
         };
         assert_eq!(output.exit_code(), 0);
     }
@@ -1916,6 +1959,8 @@ mod tests {
             test_command: "echo".to_string(),
             concurrency: 1,
             test_args: None,
+            predicted_duration: None,
+            calibration_factor: 1.0,
         };
         assert_eq!(output.exit_code(), 1);
     }
@@ -1930,6 +1975,8 @@ mod tests {
             test_command: "echo".to_string(),
             concurrency: 1,
             test_args: None,
+            predicted_duration: None,
+            calibration_factor: 1.0,
         };
         assert_eq!(output.exit_code(), 1);
     }
@@ -1949,6 +1996,8 @@ mod tests {
             test_command: "echo".to_string(),
             concurrency: 1,
             test_args: None,
+            predicted_duration: None,
+            calibration_factor: 1.0,
         };
         assert_eq!(output.exit_code(), 1);
     }
@@ -1966,6 +2015,8 @@ mod tests {
             test_command: "cargo test".to_string(),
             concurrency: 2,
             test_args: None,
+            predicted_duration: None,
+            calibration_factor: 1.0,
         };
         let test_run = output.into_test_run();
         assert_eq!(test_run.id.as_str(), "42");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1316,6 +1316,7 @@ fn test_serial_run_with_cancellation() {
             run_id,
             writer,
             &historical_times,
+            1.0,
         )
         .unwrap();
     let elapsed = start.elapsed();


### PR DESCRIPTION
Persist each run's predicted wall-clock duration alongside the actual duration, then learn an EWMA-based multiplicative correction (bucketed by concurrency) and apply it to the next run's displayed ETA. The raw historical-sum prediction is what gets stored, so future calibration math sees an unbiased baseline.

A new global --eta-debug flag prints the calibration inputs (sample counts, recent ratios, factor) before the run and a predicted-vs-actual comparison after.