### PR TITLE
Support mirroring logs into git

### DIFF
--- a/devnotes/git-mirror-design.md
+++ b/devnotes/git-mirror-design.md
@@ -1,0 +1,242 @@
+# Mirroring inquest runs into a side ref in git
+
+## Goal
+
+Optionally mirror each completed test run into a git ref so that a
+repository that records test results in `.inquest/` can also publish those
+results into git itself. With the mirror enabled, results travel with the
+history (push, fetch, share), and standard git plumbing
+(`git ls-tree`, `git cat-file`) is enough to inspect them — no inquest
+install required to read the data back.
+
+The mirror is **best-effort and one-way**. `.inquest/` remains the source
+of truth; the git ref is a derived view written after a run completes.
+
+## Storage layout
+
+All mirrored data lives under one ref:
+
+    refs/inquest
+
+This is *not* a git-notes ref — `git notes` requires note bodies to be
+blobs and we want a richer tree shape. We build the ref directly via
+plumbing.
+
+The ref points at a commit whose tree is keyed by the commit a run was
+executed against, then by run id:
+
+    <commit-sha>/<run-id>/subunit          blob — raw subunit v2 bytes
+    <commit-sha>/<run-id>/metadata.json    blob — JSON metadata for the run
+    <commit-sha>/<run-id>/stderr           blob — captured stderr (omitted when empty)
+
+The `<commit-sha>` segment is the value of `RunMetadata.git_commit` for
+the run (i.e. `git rev-parse HEAD` at the moment the run started). If
+`git_commit` is `None`, the run is not mirrored.
+
+Multiple runs on the same commit accumulate side-by-side as sibling
+`<run-id>/` subtrees. Re-mirroring an existing `<commit, run_id>` pair
+replaces just that subtree; entries for other runs and other commits are
+preserved.
+
+The ref's commits form a normal commit chain (one new commit per
+mirrored run, with the previous tip as parent). The chain is bookkeeping;
+the only tree of interest is the tip's. Keeping the chain (rather than
+collapsing) gives `git log refs/inquest` a useful audit trail and lets
+`git push --force-with-lease` keep concurrent publishers honest.
+
+### Why one blob per piece per run
+
+- **One subunit blob per run** so the byte stream has a stable git object
+  id. A consumer that wants to cite "the result of run 7 against commit
+  `abcdef`" can record the blob OID directly and that OID never changes.
+- **One metadata blob per run** so writing a new run is a strictly
+  additive tree edit. There is no shared `metadata.json` to read-modify-
+  write, no parsing-and-merging.
+- **One stderr blob per run** for the same reasons. Stored uncompressed
+  even though `.inquest/runs/<id>.stderr.gz` is gzipped on disk — git
+  packfiles already deflate blobs, double-compressing buys nothing and
+  makes `git cat-file -p <oid>` produce binary slop.
+
+### `metadata.json` schema
+
+```json
+{
+  "format": 1,
+  "run_id": "7",
+  "timestamp": "2026-04-29T10:11:12Z",
+  "command": "cargo test --workspace",
+  "concurrency": 8,
+  "duration_secs": 142.3,
+  "exit_code": 0,
+  "test_args": ["--", "--nocapture"],
+  "profile": "ci",
+  "git_dirty": false,
+  "totals": {
+    "total": 412,
+    "failures": 0,
+    "errors": 0,
+    "skips": 3
+  }
+}
+```
+
+All fields except `format` and `run_id` are optional. Unknown fields
+must be ignored by readers. `format` is bumped only on incompatible
+changes; new fields land behind `skip_serializing_if = "Option::is_none"`
+so older readers keep working.
+
+## Config
+
+```toml
+mirror_to_git_notes = true
+```
+
+The historical name has stuck even after dropping `git notes`. Default
+unset → off. Standard profile overlay applies.
+
+## Mirroring algorithm
+
+For one completed run:
+
+1. **Probe** — `git rev-parse --git-dir`. If we're not in a git repo, no-op
+   at `info!`.
+2. **Skip when no anchor commit** — if `metadata.git_commit` is `None`, no-op
+   at `debug!`.
+3. **Hash the data blobs** — read subunit, metadata JSON, and (if non-empty)
+   captured stderr; pipe each through `git hash-object -w --stdin` to
+   produce three OIDs.
+4. **Read the existing tree** for `refs/inquest`, if any. Otherwise start
+   with an empty root tree.
+5. **Splice** — replace the subtree at `<commit>/<run_id>/` with one
+   containing `subunit`, `metadata.json`, and `stderr` (the latter only
+   when present). Through a temporary index:
+   - `GIT_INDEX_FILE=tmp git read-tree <existing-root>` (skip when none).
+   - `GIT_INDEX_FILE=tmp git rm --cached -r --quiet --ignore-unmatch -- <commit>/<run_id>`
+     drops any prior mirror of this exact `(commit, run_id)` so vestigial
+     files (e.g. an old `stderr`) don't survive.
+   - For each new entry: `GIT_INDEX_FILE=tmp git update-index --add --cacheinfo 100644,<oid>,<commit>/<run_id>/<file>`.
+   - `GIT_INDEX_FILE=tmp git write-tree` → new root OID.
+6. **Commit** — `git commit-tree <root> [-p <prev-tip>] -m "..."` with a
+   fixed inquest committer identity.
+7. **Update the ref** — `git update-ref refs/inquest <new> <expected-prev>`.
+   The expected-OID gates concurrent writers: a racing mirror loses the
+   race and we log a warning.
+
+All errors during mirroring are turned into `tracing::warn!` by the
+caller; mirroring never fails a run.
+
+## Git tooling
+
+Pure shell-out via `std::process::Command`, consistent with the rest of
+inquest's git interaction. The full command set:
+
+- `git rev-parse --git-dir`
+- `git rev-parse --verify --quiet refs/inquest`
+- `git hash-object -w --stdin`
+- `git read-tree <oid>` (under a per-call `GIT_INDEX_FILE`)
+- `git update-index --add --cacheinfo / --remove`
+- `git write-tree`
+- `git commit-tree`
+- `git update-ref`
+- `git ls-tree` for reads
+
+`gix` / `git2` would be cleaner for high-volume publishers and is a
+viable future swap; the module is the only place that would need to
+change.
+
+## Failure handling
+
+| Condition                                              | Behaviour                                  |
+|--------------------------------------------------------|--------------------------------------------|
+| Not inside a git repository                            | no-op, `info!`                             |
+| `git` not on `PATH`                                    | no-op, `info!`                             |
+| `metadata.git_commit` is `None`                        | no-op, `debug!`                            |
+| Captured stderr is empty                               | omit the `stderr` blob; mirror metadata + subunit |
+| `git hash-object` / `update-index` / `write-tree` fails | `warn!`, run still succeeds                |
+| `git update-ref` fails (concurrent writer)             | `warn!`, run still succeeds, mirror is lost |
+| Existing tree at `<commit>/<run>/` has unexpected shape | overwrite — newer mirror wins              |
+
+## Inspecting from the CLI
+
+```sh
+# What commits have mirrored runs?
+git ls-tree refs/inquest
+
+# What runs ran against this commit?
+git ls-tree refs/inquest:<commit>
+
+# Inspect run 7's metadata against <commit>:
+git cat-file -p refs/inquest:<commit>/7/metadata.json
+
+# Pipe the subunit stream into a consumer:
+git cat-file -p refs/inquest:<commit>/7/subunit | subunit-stats
+
+# Read captured stderr if any:
+git cat-file -p refs/inquest:<commit>/7/stderr
+```
+
+Path autocompletion under `git cat-file` doesn't follow refs, so
+`refs/inquest:<commit>/<TAB>` doesn't expand — `git ls-tree` first.
+
+## Sharing via remotes
+
+`refs/inquest` is not under `refs/heads/` or `refs/tags/`, so it is not
+pushed or fetched by default. Inquest does not push automatically; that
+is a deliberate user/CI policy choice.
+
+To publish:
+
+```sh
+git push origin 'refs/inquest:refs/inquest'
+```
+
+To subscribe (one-time per clone):
+
+```sh
+git config --add remote.origin.fetch '+refs/inquest:refs/inquest'
+git fetch origin
+```
+
+GitHub stores and serves the ref but does not display it in the web UI
+and applies no branch-protection rules to it. It is effectively
+write-anything-with-push-access.
+
+### Concurrent publishers
+
+`update-ref` is a fast-forward with an expected-OID check, so concurrent
+writers serialise: the loser sees a conflict and (in inquest's case)
+warns and gives up. A CI setup with multiple machines pushing to the
+same remote needs either:
+
+- A single publisher (one CI job dedicated to publishing), or
+- Retry-with-rebase on the publisher: re-read the remote tip, splice
+  the new run on top, push again. We don't implement this today.
+
+A separate concern: run ids are sequential per local `.inquest/`, so
+two CI workers will both produce run 0 and clobber one another's data
+under the same commit. If push-from-many-publishers becomes a real
+workflow, run ids likely need a per-publisher disambiguator (CI job id,
+hostname, UUID prefix). Out of scope for the initial mirror.
+
+## Storage cost
+
+Each run on each commit adds one subunit blob, one metadata blob, and
+optionally one stderr blob. Subunit is binary but compresses well in
+packfiles; identical blobs across runs deduplicate to a single OID
+automatically. A repo with thousands of runs is fine; a repo with
+millions of runs starts to hit GitHub's soft 5 GB recommended limit.
+Pruning is out of scope for this iteration — see open questions.
+
+## Out of scope (deliberately)
+
+- Reading runs *from* the mirror back into `.inquest/`. Inquest never
+  reads the ref; `.inquest/` remains the source of truth.
+- Auto-pushing on mirror. The user/CI decides when to push.
+- Pruning the ref when corresponding `.inquest/` runs are pruned. The
+  mirror's per-commit subtree may still be useful even if the local
+  data is gone.
+- Backfilling existing local runs into the mirror. Easy follow-up
+  (`inq mirror --backfill`).
+- Per-publisher run-id disambiguation for shared remotes (see above).
+- Switching from shell-out to `gix`/`git2`. Local optimisation, no
+  externally-visible change.

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -191,8 +191,9 @@ impl RunCommand {
         filter_tags: &[String],
         stderr_capture: Option<&std::sync::Arc<std::sync::Mutex<Vec<u8>>>>,
         active_profile: Option<&str>,
+        mirror_to_git_notes: bool,
     ) -> Result<CliRunOutput> {
-        let (exit_code, run_id) = crate::commands::utils::persist_and_display_run(
+        let (exit_code, run_id, totals) = crate::commands::utils::persist_and_display_run(
             ui,
             repo,
             output,
@@ -208,6 +209,13 @@ impl RunCommand {
                 Err(poisoned) => std::mem::take(&mut *poisoned.into_inner()),
             };
             repo.set_run_stderr(&run_id, &bytes)?;
+        }
+        // Mirror after stderr is persisted so it can be picked up too.
+        // Mirroring is best-effort: log and continue on failure.
+        if mirror_to_git_notes {
+            if let Err(e) = crate::commands::utils::mirror_run_to_git(repo, &run_id, totals) {
+                tracing::warn!("git mirror failed for run {}: {}", run_id, e);
+            }
         }
         Ok(CliRunOutput {
             exit_code,
@@ -407,6 +415,7 @@ impl RunCommand {
             .unwrap_or_else(|| std::sync::Arc::new(std::sync::Mutex::new(Vec::new())));
         let config = self.executor_config(Some(stderr_capture.clone()));
         let executor = TestExecutor::new(&config);
+        let mirror_to_git_notes = test_cmd.config().mirror_to_git_notes.unwrap_or(false);
 
         if self.subunit {
             let (run_id, writer) = repo.begin_test_run_raw()?;
@@ -421,6 +430,7 @@ impl RunCommand {
                 &filter_tags,
                 Some(&stderr_capture),
                 active_profile.as_deref(),
+                mirror_to_git_notes,
             );
         }
 
@@ -529,6 +539,7 @@ impl RunCommand {
                         &filter_tags,
                         Some(&stderr_capture),
                         active_profile.as_deref(),
+                        mirror_to_git_notes,
                     )?;
 
                     if result.exit_code != 0 {
@@ -555,6 +566,7 @@ impl RunCommand {
                     &filter_tags,
                     Some(&stderr_capture),
                     active_profile.as_deref(),
+                    mirror_to_git_notes,
                 )
             }
         } else if self.until_failure {
@@ -612,6 +624,7 @@ impl RunCommand {
                     &filter_tags,
                     Some(&stderr_capture),
                     active_profile.as_deref(),
+                    mirror_to_git_notes,
                 )?;
 
                 if result.exit_code != 0 {
@@ -645,6 +658,7 @@ impl RunCommand {
                 &filter_tags,
                 Some(&stderr_capture),
                 active_profile.as_deref(),
+                mirror_to_git_notes,
             )
         } else {
             let (run_id, writer) = repo.begin_test_run_raw()?;
@@ -669,6 +683,7 @@ impl RunCommand {
                 &filter_tags,
                 Some(&stderr_capture),
                 active_profile.as_deref(),
+                mirror_to_git_notes,
             )
         }
     }

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -366,11 +366,9 @@ pub fn warn_slow_tests(
 
 /// Persist a completed test run to the repository and display summary.
 ///
-/// Persist a completed test run to the repository and display summary.
-///
-/// Returns `(exit_code, run_id)`. The `run_id` is returned because `output`
-/// is consumed, saving the caller from cloning it beforehand.
-#[allow(clippy::too_many_arguments)]
+/// Returns `(exit_code, run_id, totals)`. `run_id` is returned because
+/// `output` is consumed, and `totals` is returned so the caller can pass
+/// them on to [`mirror_run_to_git`] without recomputing.
 pub fn persist_and_display_run(
     ui: &mut dyn UI,
     repo: &mut dyn Repository,
@@ -380,7 +378,7 @@ pub fn persist_and_display_run(
     filter_tags: &[String],
     profile: Option<String>,
     eta_debug: bool,
-) -> Result<(i32, RunId)> {
+) -> Result<(i32, RunId, crate::git_notes::RunTotals)> {
     let exit_code = output.exit_code();
     let crate::test_executor::RunOutput {
         run_id,
@@ -414,6 +412,7 @@ pub fn persist_and_display_run(
         predicted_duration,
     )?;
 
+    let totals = crate::git_notes::RunTotals::from_run(&combined_run);
     display_test_summary(ui, &run_id, &combined_run, filter_tags)?;
     if eta_debug {
         if let Some(predicted) = predicted_duration {
@@ -422,7 +421,33 @@ pub fn persist_and_display_run(
     }
     warn_slow_tests(ui, &combined_run, historical_times)?;
 
-    Ok((exit_code, run_id))
+    Ok((exit_code, run_id, totals))
+}
+
+/// Mirror a freshly-persisted run into the inquest git side ref.
+///
+/// Reads run metadata, captured stderr, and timestamp back from `repo` so
+/// the mirror sees exactly what was just persisted. Errors are returned to
+/// the caller, who is expected to log-and-swallow — mirroring failure must
+/// never fail a run.
+pub fn mirror_run_to_git(
+    repo: &dyn Repository,
+    run_id: &RunId,
+    totals: crate::git_notes::RunTotals,
+) -> Result<()> {
+    let metadata = repo.get_run_metadata(run_id)?;
+    let started_at = repo.get_run_started_at(run_id)?;
+    let timestamp = started_at.map(|t| t.to_rfc3339());
+    let stderr = repo.get_run_stderr(run_id)?;
+    crate::git_notes::mirror_run(
+        repo,
+        run_id,
+        &metadata,
+        totals,
+        timestamp.as_deref(),
+        stderr.as_deref(),
+        crate::git_notes::DEFAULT_MIRROR_REF,
+    )
 }
 
 #[cfg(test)]
@@ -858,7 +883,7 @@ mod tests {
 
         let mut ui = crate::ui::test_ui::TestUI::new();
         let historical = std::collections::HashMap::new();
-        let (exit_code, run_id) = persist_and_display_run(
+        let (exit_code, run_id, _totals) = persist_and_display_run(
             &mut ui,
             repo.as_mut(),
             output,
@@ -950,7 +975,7 @@ mod tests {
 
         let mut ui = crate::ui::test_ui::TestUI::new();
         let historical = std::collections::HashMap::new();
-        let (exit_code, run_id) = persist_and_display_run(
+        let (exit_code, run_id, _totals) = persist_and_display_run(
             &mut ui,
             repo.as_mut(),
             output,

--- a/src/config.rs
+++ b/src/config.rs
@@ -250,6 +250,11 @@ pub struct ConfigLayer {
     /// Default test ordering strategy
     #[serde(skip_serializing_if = "Option::is_none")]
     pub test_order: Option<String>,
+    /// Mirror each completed run into git notes — one blob per run for the
+    /// subunit stream and one for the metadata JSON, attached to the commit
+    /// the run was executed against under `refs/notes/inquest`. Opt-in.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mirror_to_git_notes: Option<bool>,
 }
 
 impl ConfigLayer {
@@ -320,6 +325,7 @@ impl ConfigLayer {
         overlay_field!(instance_execute);
         overlay_field!(instance_dispose);
         overlay_field!(test_order);
+        overlay_field!(mirror_to_git_notes);
     }
 }
 
@@ -503,6 +509,7 @@ impl ConfigFile {
         check!(instance_execute);
         check!(instance_dispose);
         check!(test_order);
+        check!(mirror_to_git_notes);
         set
     }
 
@@ -573,6 +580,9 @@ fn parse_ini_base(contents: &str) -> Result<ConfigLayer> {
         instance_execute: default.get("instance_execute").cloned(),
         instance_dispose: default.get("instance_dispose").cloned(),
         test_order: default.get("test_order").cloned(),
+        // mirror_to_git_notes is not exposed in the legacy .testr.conf format;
+        // it is only configurable from inquest.toml.
+        mirror_to_git_notes: None,
     })
 }
 
@@ -630,6 +640,10 @@ pub struct TestrConfig {
     /// "alphabetical", "failing-first", "spread", "shuffle[:<seed>]",
     /// "slowest-first", "fastest-first", "frequent-failing-first".
     pub test_order: Option<String>,
+
+    /// Mirror each completed run into git notes under `refs/notes/inquest`.
+    /// Best-effort and one-way: `.inquest/` remains the source of truth.
+    pub mirror_to_git_notes: Option<bool>,
 }
 
 impl TestrConfig {
@@ -713,6 +727,7 @@ impl TestrConfig {
             instance_execute: layer.instance_execute,
             instance_dispose: layer.instance_dispose,
             test_order: layer.test_order,
+            mirror_to_git_notes: layer.mirror_to_git_notes,
         })
     }
 
@@ -1569,5 +1584,52 @@ test_list_option = "--list"
         let (resolved, active) = cfg.resolve(None).unwrap();
         assert!(active.is_none());
         assert_eq!(resolved.test_command, "cargo subunit $LISTOPT $IDOPTION");
+    }
+
+    #[test]
+    fn mirror_to_git_notes_defaults_to_none() {
+        let cfg = ConfigFile::parse_toml(r#"test_command = "echo""#).unwrap();
+        let (resolved, _) = cfg.resolve(None).unwrap();
+        assert_eq!(resolved.mirror_to_git_notes, None);
+    }
+
+    #[test]
+    fn mirror_to_git_notes_round_trips_via_toml() {
+        let cfg = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+mirror_to_git_notes = true
+"#,
+        )
+        .unwrap();
+        let (resolved, _) = cfg.resolve(None).unwrap();
+        assert_eq!(resolved.mirror_to_git_notes, Some(true));
+
+        let serialized = resolved.to_toml().unwrap();
+        assert!(serialized.contains("mirror_to_git_notes = true"));
+    }
+
+    #[test]
+    fn mirror_to_git_notes_profile_overlay() {
+        let cfg = ConfigFile::parse_toml(
+            r#"
+test_command = "echo"
+mirror_to_git_notes = false
+
+[profiles.share]
+mirror_to_git_notes = true
+"#,
+        )
+        .unwrap();
+
+        let (base, _) = cfg.resolve(None).unwrap();
+        assert_eq!(base.mirror_to_git_notes, Some(false));
+
+        let (overlaid, active) = cfg.resolve(Some("share")).unwrap();
+        assert_eq!(active.as_deref(), Some("share"));
+        assert_eq!(overlaid.mirror_to_git_notes, Some(true));
+
+        let from = cfg.fields_from_profile(Some("share"));
+        assert!(from.contains("mirror_to_git_notes"));
     }
 }

--- a/src/git_notes.rs
+++ b/src/git_notes.rs
@@ -1,0 +1,822 @@
+//! Mirror inquest test runs into a side ref in git.
+//!
+//! When the `mirror_to_git_notes` config flag is enabled, each completed run
+//! is published into the ref [`DEFAULT_MIRROR_REF`] as three blobs — the raw
+//! subunit byte stream, a JSON metadata document, and (when non-empty) the
+//! captured stderr — under the path
+//!
+//! ```text
+//! <commit-sha>/<run-id>/subunit
+//! <commit-sha>/<run-id>/metadata.json
+//! <commit-sha>/<run-id>/stderr
+//! ```
+//!
+//! The mirror is best-effort and one-way: `.inquest/` remains the source of
+//! truth, and any failure inside this module is reported as `Err(...)` so the
+//! caller can log-and-swallow. A run never fails because of a mirroring
+//! problem.
+//!
+//! See `devnotes/git-mirror-design.md` for the full design.
+//!
+//! The module name is historical; this is no longer based on git notes.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use serde::Serialize;
+
+use crate::error::{Error, Result};
+use crate::repository::{Repository, RunId, RunMetadata, TestRun};
+
+/// The git ref under which inquest publishes mirrored runs.
+pub const DEFAULT_MIRROR_REF: &str = "refs/inquest";
+
+/// Schema version embedded in each `metadata.json` blob.
+const METADATA_FORMAT_VERSION: u32 = 1;
+
+/// Summary counts written into the metadata blob alongside [`RunMetadata`].
+///
+/// Computed from a [`TestRun`] before the mirror is invoked so that a
+/// consumer can answer "did this run pass?" without parsing the subunit
+/// stream.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RunTotals {
+    /// Total number of tests recorded in the run.
+    pub total: usize,
+    /// Tests whose status is [`crate::repository::TestStatus::Failure`].
+    pub failures: usize,
+    /// Tests whose status is [`crate::repository::TestStatus::Error`].
+    pub errors: usize,
+    /// Tests whose status is [`crate::repository::TestStatus::Skip`].
+    pub skips: usize,
+}
+
+impl RunTotals {
+    /// Compute totals from a [`TestRun`].
+    pub fn from_run(run: &TestRun) -> Self {
+        use crate::repository::TestStatus;
+        let mut totals = RunTotals {
+            total: run.total_tests(),
+            ..RunTotals::default()
+        };
+        for result in run.results.values() {
+            match result.status {
+                TestStatus::Failure => totals.failures += 1,
+                TestStatus::Error => totals.errors += 1,
+                TestStatus::Skip => totals.skips += 1,
+                _ => {}
+            }
+        }
+        totals
+    }
+}
+
+/// JSON shape of the `metadata.json` blob written for each mirrored run.
+///
+/// Field names are stable across schema versions; new fields are added
+/// behind `#[serde(skip_serializing_if = "Option::is_none")]` so older
+/// readers keep working.
+#[derive(Debug, Serialize)]
+struct MetadataDoc<'a> {
+    format: u32,
+    run_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timestamp: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    command: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    concurrency: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration_secs: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    test_args: Option<&'a [String]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    profile: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    git_dirty: Option<bool>,
+    totals: TotalsDoc,
+}
+
+#[derive(Debug, Serialize)]
+struct TotalsDoc {
+    total: usize,
+    failures: usize,
+    errors: usize,
+    skips: usize,
+}
+
+impl From<RunTotals> for TotalsDoc {
+    fn from(t: RunTotals) -> Self {
+        TotalsDoc {
+            total: t.total,
+            failures: t.failures,
+            errors: t.errors,
+            skips: t.skips,
+        }
+    }
+}
+
+/// Mirror a single completed run into the side ref `mirror_ref`.
+///
+/// Reads the run's subunit stream from `repo`, builds the metadata JSON,
+/// and splices `<commit>/<run_id>/{subunit,metadata.json,stderr}` into the
+/// existing root tree (creating the ref if it doesn't exist yet).
+///
+/// `stderr_bytes` is `None` when no stderr was captured and `Some(&[])` when
+/// the captured stderr was empty; both cases omit the `stderr` blob.
+///
+/// The function is intentionally permissive about its environment:
+///
+/// - Returns `Ok(())` (a no-op) when the working directory is not inside a
+///   git repository, or when `metadata.git_commit` is `None`. Both are
+///   normal conditions, not errors.
+/// - Any underlying git or I/O failure is reported as `Err(...)` so the
+///   caller can decide whether to log-and-swallow.
+///
+/// Callers in production paths should treat any `Err` as a `tracing::warn!`
+/// and continue — mirroring failure must not fail the run.
+pub fn mirror_run(
+    repo: &dyn Repository,
+    run_id: &RunId,
+    metadata: &RunMetadata,
+    totals: RunTotals,
+    timestamp: Option<&str>,
+    stderr_bytes: Option<&[u8]>,
+    mirror_ref: &str,
+) -> Result<()> {
+    let Some(commit) = metadata.git_commit.as_deref() else {
+        tracing::debug!(
+            "skipping git mirror for run {}: no git_commit recorded",
+            run_id
+        );
+        return Ok(());
+    };
+
+    if !is_git_repo()? {
+        tracing::info!("skipping git mirror: not inside a git repository");
+        return Ok(());
+    }
+
+    // Hash the data blobs.
+    let mut subunit_bytes = Vec::new();
+    let mut reader = repo.get_test_run_raw(run_id)?;
+    std::io::copy(&mut reader, &mut subunit_bytes)?;
+    let subunit_oid = write_blob(&subunit_bytes)?;
+
+    let doc = MetadataDoc {
+        format: METADATA_FORMAT_VERSION,
+        run_id: run_id.as_str(),
+        timestamp,
+        command: metadata.command.as_deref(),
+        concurrency: metadata.concurrency,
+        duration_secs: metadata.duration_secs,
+        exit_code: metadata.exit_code,
+        test_args: metadata.test_args.as_deref(),
+        profile: metadata.profile.as_deref(),
+        git_dirty: metadata.git_dirty,
+        totals: totals.into(),
+    };
+    let metadata_json = serde_json::to_vec_pretty(&doc)
+        .map_err(|e| Error::Other(format!("failed to serialize mirror metadata: {}", e)))?;
+    let metadata_oid = write_blob(&metadata_json)?;
+
+    let stderr_oid = match stderr_bytes {
+        Some(bytes) if !bytes.is_empty() => Some(write_blob(bytes)?),
+        _ => None,
+    };
+
+    // Splice into the existing root tree (or start from scratch).
+    let parent_commit = read_ref(mirror_ref)?;
+    let new_root = splice_run_into_root(
+        parent_commit.as_deref(),
+        commit,
+        run_id.as_str(),
+        &subunit_oid,
+        &metadata_oid,
+        stderr_oid.as_deref(),
+    )?;
+
+    let new_commit = commit_tree(
+        &new_root,
+        parent_commit.as_deref(),
+        &format!("inquest run {} on {}", run_id.as_str(), commit),
+    )?;
+    update_ref(mirror_ref, &new_commit, parent_commit.as_deref())?;
+    Ok(())
+}
+
+/// Build a new root tree by loading the existing one (if any), wiping the
+/// `<commit>/<run_id>/` subtree (so vestigial files from a prior mirror of
+/// this exact pair don't survive), and adding the fresh blobs.
+fn splice_run_into_root(
+    parent_commit: Option<&str>,
+    commit: &str,
+    run_id: &str,
+    subunit_oid: &str,
+    metadata_oid: &str,
+    stderr_oid: Option<&str>,
+) -> Result<String> {
+    let index_dir = tempfile::TempDir::new()
+        .map_err(|e| Error::Other(format!("creating temporary index dir: {}", e)))?;
+    let index_path = index_dir.path().join("index");
+
+    if let Some(parent) = parent_commit {
+        // Load the parent commit's tree into the temp index.
+        run_git_with_index(
+            &index_path,
+            &["read-tree", &format!("{}^{{tree}}", parent)],
+            None,
+        )?;
+        // Drop any prior mirror of this exact (commit, run_id). `--cached`
+        // operates only on the index, `--ignore-unmatch` makes the
+        // first-mirror case a no-op rather than an error.
+        run_git_with_index(
+            &index_path,
+            &[
+                "rm",
+                "--cached",
+                "-r",
+                "--quiet",
+                "--ignore-unmatch",
+                "--",
+                &format!("{}/{}", commit, run_id),
+            ],
+            None,
+        )?;
+    }
+
+    // Add the new entries.
+    let entries = std::iter::once(("subunit", subunit_oid))
+        .chain(std::iter::once(("metadata.json", metadata_oid)))
+        .chain(stderr_oid.map(|oid| ("stderr", oid)));
+    for (name, oid) in entries {
+        let path = format!("{}/{}/{}", commit, run_id, name);
+        let cacheinfo = format!("100644,{},{}", oid, path);
+        run_git_with_index(
+            &index_path,
+            &["update-index", "--add", "--cacheinfo", &cacheinfo],
+            None,
+        )?;
+    }
+
+    let tree_oid_bytes = run_git_with_index(&index_path, &["write-tree"], None)?;
+    drop(index_dir);
+    Ok(String::from_utf8_lossy(&tree_oid_bytes).trim().to_string())
+}
+
+/// Run `git <args>` against the temp index at `index_path`, returning
+/// captured stdout. Stdin is fed `stdin_bytes` when supplied.
+fn run_git_with_index(
+    index_path: &Path,
+    args: &[&str],
+    stdin_bytes: Option<&[u8]>,
+) -> Result<Vec<u8>> {
+    let mut cmd = Command::new("git");
+    cmd.args(args).env("GIT_INDEX_FILE", index_path);
+    if stdin_bytes.is_some() {
+        cmd.stdin(Stdio::piped());
+    }
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| Error::Other(format!("failed to spawn `git {}`: {}", args[0], e)))?;
+    if let Some(bytes) = stdin_bytes {
+        let stdin = child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| Error::Other(format!("git {} stdin unavailable", args[0])))?;
+        stdin.write_all(bytes)?;
+    }
+    let output = child
+        .wait_with_output()
+        .map_err(|e| Error::Other(format!("waiting on `git {}` failed: {}", args[0], e)))?;
+    if !output.status.success() {
+        return Err(Error::Other(format!(
+            "git {} failed: {}",
+            args[0],
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(output.stdout)
+}
+
+/// Probe whether the current working directory is inside a git working tree
+/// or a bare repository. Returns `Ok(false)` (not `Err`) when `git` exits
+/// non-zero or is missing — those are user-visible conditions that the
+/// caller turns into a no-op, not a hard failure.
+fn is_git_repo() -> Result<bool> {
+    match Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+    {
+        Ok(status) => Ok(status.success()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(Error::Io(e)),
+    }
+}
+
+/// Write `bytes` to the git object store as a blob and return its OID.
+fn write_blob(bytes: &[u8]) -> Result<String> {
+    let mut child = Command::new("git")
+        .args(["hash-object", "-w", "--stdin"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| Error::Other(format!("failed to spawn `git hash-object`: {}", e)))?;
+    {
+        let stdin = child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| Error::Other("git hash-object stdin unavailable".into()))?;
+        stdin.write_all(bytes)?;
+    }
+    let output = child
+        .wait_with_output()
+        .map_err(|e| Error::Other(format!("waiting on `git hash-object` failed: {}", e)))?;
+    if !output.status.success() {
+        return Err(Error::Other(format!(
+            "git hash-object failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    let oid = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if oid.is_empty() {
+        return Err(Error::Other(
+            "git hash-object returned empty OID".to_string(),
+        ));
+    }
+    Ok(oid)
+}
+
+/// Resolve `ref_name` to a commit OID. Returns `None` when the ref does
+/// not exist yet.
+fn read_ref(ref_name: &str) -> Result<Option<String>> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", ref_name])
+        .output()
+        .map_err(|e| Error::Other(format!("failed to spawn `git rev-parse`: {}", e)))?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let oid = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if oid.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(oid))
+    }
+}
+
+/// Create a commit whose tree is `tree_oid`, with optional `parent`.
+/// Author/committer are set to a fixed inquest identity via env vars so
+/// we don't need to depend on the user's `user.email` / `user.name`. We
+/// also force `commit.gpgsign=false` for the same reason — mirror commits
+/// are bookkeeping, not user-authored history.
+fn commit_tree(tree_oid: &str, parent: Option<&str>, message: &str) -> Result<String> {
+    let mut args: Vec<String> = vec!["commit-tree".into(), tree_oid.into()];
+    if let Some(p) = parent {
+        args.push("-p".into());
+        args.push(p.into());
+    }
+    args.push("-m".into());
+    args.push(message.into());
+
+    let output = Command::new("git")
+        .args(&args)
+        .env("GIT_AUTHOR_NAME", "inquest")
+        .env("GIT_AUTHOR_EMAIL", "inquest@localhost")
+        .env("GIT_COMMITTER_NAME", "inquest")
+        .env("GIT_COMMITTER_EMAIL", "inquest@localhost")
+        .env("GIT_CONFIG_COUNT", "1")
+        .env("GIT_CONFIG_KEY_0", "commit.gpgsign")
+        .env("GIT_CONFIG_VALUE_0", "false")
+        .output()
+        .map_err(|e| Error::Other(format!("failed to spawn `git commit-tree`: {}", e)))?;
+    if !output.status.success() {
+        return Err(Error::Other(format!(
+            "git commit-tree failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Atomically move `ref_name` from `expected` to `new_oid`. When `expected`
+/// is `None`, the ref is created (the all-zeros OID is the standard
+/// "ref must not exist" sentinel for `update-ref`).
+fn update_ref(ref_name: &str, new_oid: &str, expected: Option<&str>) -> Result<()> {
+    let zero = "0000000000000000000000000000000000000000";
+    let expected_arg = expected.unwrap_or(zero);
+    let output = Command::new("git")
+        .args(["update-ref", ref_name, new_oid, expected_arg])
+        .output()
+        .map_err(|e| Error::Other(format!("failed to spawn `git update-ref`: {}", e)))?;
+    if !output.status.success() {
+        return Err(Error::Other(format!(
+            "git update-ref failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repository::inquest::InquestRepositoryFactory;
+    use crate::repository::{RepositoryFactory, TestId, TestResult, TestStatus};
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    /// Run `git` with `args` inside `cwd`, asserting it succeeds. Returns
+    /// stdout as a `Vec<u8>` so tests can compare binary blobs byte-for-byte.
+    fn git_in(cwd: &Path, args: &[&str]) -> Vec<u8> {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to spawn git {:?}: {}", args, e));
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output.stdout
+    }
+
+    /// Run `git` and return stdout as a trimmed `String`.
+    fn git_str(cwd: &Path, args: &[&str]) -> String {
+        let bytes = git_in(cwd, args);
+        String::from_utf8(bytes).unwrap().trim().to_string()
+    }
+
+    /// `git init` in `cwd` and make one empty commit so HEAD points to
+    /// something the mirror can attach data to.
+    fn init_git_repo(cwd: &Path) -> String {
+        git_in(cwd, &["init", "-q", "-b", "main"]);
+        // Local identity & no signing: tests must not depend on a user's
+        // global git config (which on dev machines often signs commits).
+        git_in(cwd, &["config", "user.email", "tests@example.com"]);
+        git_in(cwd, &["config", "user.name", "tests"]);
+        git_in(cwd, &["config", "commit.gpgsign", "false"]);
+        git_in(cwd, &["config", "tag.gpgsign", "false"]);
+        git_in(cwd, &["commit", "--allow-empty", "-m", "init", "-q"]);
+        git_str(cwd, &["rev-parse", "HEAD"])
+    }
+
+    /// Build an inquest repository in `cwd/.inquest` with one run whose
+    /// subunit stream contains `payload`.
+    fn make_repo_with_run(cwd: &Path, payload: &[u8]) -> (Box<dyn Repository>, RunId) {
+        let factory = InquestRepositoryFactory;
+        let mut repo = factory.initialise(cwd).unwrap();
+        let (run_id, mut writer) = repo.begin_test_run_raw().unwrap();
+        writer.write_all(payload).unwrap();
+        writer.flush().unwrap();
+        drop(writer);
+        (repo, run_id)
+    }
+
+    /// Construct a `RunMetadata` with the given commit hash; everything else
+    /// uses sensible defaults so tests don't need to write boilerplate.
+    fn metadata_for(commit: &str) -> RunMetadata {
+        RunMetadata {
+            git_commit: Some(commit.to_string()),
+            git_dirty: Some(false),
+            command: Some("test".to_string()),
+            concurrency: Some(1),
+            duration_secs: Some(0.5),
+            exit_code: Some(0),
+            test_args: None,
+            profile: None,
+            predicted_duration_secs: None,
+        }
+    }
+
+    /// Look up the OID of a path inside the mirror ref's root tree.
+    /// Returns `None` when the entry is missing.
+    fn lookup_entry(cwd: &Path, mirror_ref: &str, path: &str) -> Option<String> {
+        let spec = format!("{}^{{tree}}", mirror_ref);
+        let output = Command::new("git")
+            .args(["ls-tree", "-r", &spec])
+            .current_dir(cwd)
+            .output()
+            .unwrap();
+        if !output.status.success() {
+            return None;
+        }
+        let listing = String::from_utf8_lossy(&output.stdout).into_owned();
+        for line in listing.lines() {
+            // "<mode> <kind> <oid>\t<path>"
+            let (header, entry_path) = line.split_once('\t')?;
+            if entry_path == path {
+                let oid = header.split_whitespace().nth(2)?;
+                return Some(oid.to_string());
+            }
+        }
+        None
+    }
+
+    /// Run the mirror with `cwd` set to the test repo so the shelled-out
+    /// `git` calls land in the right place.
+    fn mirror_with_cwd(
+        cwd: &Path,
+        repo: &dyn Repository,
+        run_id: &RunId,
+        metadata: &RunMetadata,
+        totals: RunTotals,
+        stderr_bytes: Option<&[u8]>,
+    ) -> Result<()> {
+        // The functions in this module shell out via `Command::new("git")`,
+        // which uses the *process's* working directory. Tests run in
+        // parallel, so we briefly take a process-wide lock around the
+        // `set_current_dir` + mirror call.
+        let _guard = TEST_CWD_LOCK.lock().unwrap();
+        let original = std::env::current_dir().unwrap();
+        std::env::set_current_dir(cwd).unwrap();
+        let result = mirror_run(
+            repo,
+            run_id,
+            metadata,
+            totals,
+            None,
+            stderr_bytes,
+            DEFAULT_MIRROR_REF,
+        );
+        std::env::set_current_dir(original).unwrap();
+        result
+    }
+
+    static TEST_CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn mirror_round_trip_on_fresh_repo() {
+        let temp = TempDir::new().unwrap();
+        let cwd = temp.path();
+        let commit = init_git_repo(cwd);
+
+        let payload = b"\xb3subunit-bytes-here";
+        let (repo, run_id) = make_repo_with_run(cwd, payload);
+        let metadata = metadata_for(&commit);
+
+        mirror_with_cwd(cwd, &*repo, &run_id, &metadata, RunTotals::default(), None).unwrap();
+
+        let subunit_path = format!("{}/{}/subunit", commit, run_id.as_str());
+        let metadata_path = format!("{}/{}/metadata.json", commit, run_id.as_str());
+        let stderr_path = format!("{}/{}/stderr", commit, run_id.as_str());
+
+        let subunit_oid =
+            lookup_entry(cwd, DEFAULT_MIRROR_REF, &subunit_path).expect("subunit entry");
+        let metadata_oid =
+            lookup_entry(cwd, DEFAULT_MIRROR_REF, &metadata_path).expect("metadata entry");
+
+        // Subunit blob round-trips byte-for-byte.
+        let blob = git_in(cwd, &["cat-file", "-p", &subunit_oid]);
+        assert_eq!(blob, payload);
+
+        // Metadata blob is well-formed JSON with the expected fields.
+        let meta_bytes = git_in(cwd, &["cat-file", "-p", &metadata_oid]);
+        let value: serde_json::Value = serde_json::from_slice(&meta_bytes).unwrap();
+        assert_eq!(value["format"], 1);
+        assert_eq!(value["run_id"], run_id.as_str());
+        assert_eq!(value["command"], "test");
+
+        // No stderr was supplied, so the entry must not exist.
+        assert_eq!(lookup_entry(cwd, DEFAULT_MIRROR_REF, &stderr_path), None);
+    }
+
+    #[test]
+    fn mirror_two_runs_share_the_root_tree() {
+        let temp = TempDir::new().unwrap();
+        let cwd = temp.path();
+        let commit = init_git_repo(cwd);
+
+        let factory = InquestRepositoryFactory;
+        let mut repo = factory.initialise(cwd).unwrap();
+
+        let (run0, mut w) = repo.begin_test_run_raw().unwrap();
+        w.write_all(b"first").unwrap();
+        drop(w);
+        let metadata = metadata_for(&commit);
+        mirror_with_cwd(cwd, &*repo, &run0, &metadata, RunTotals::default(), None).unwrap();
+
+        let (run1, mut w) = repo.begin_test_run_raw().unwrap();
+        w.write_all(b"second").unwrap();
+        drop(w);
+        mirror_with_cwd(cwd, &*repo, &run1, &metadata, RunTotals::default(), None).unwrap();
+
+        let oid0 = lookup_entry(
+            cwd,
+            DEFAULT_MIRROR_REF,
+            &format!("{}/{}/subunit", commit, run0.as_str()),
+        )
+        .expect("first run preserved");
+        let oid1 = lookup_entry(
+            cwd,
+            DEFAULT_MIRROR_REF,
+            &format!("{}/{}/subunit", commit, run1.as_str()),
+        )
+        .expect("second run added");
+        assert_ne!(oid0, oid1);
+        assert_eq!(git_in(cwd, &["cat-file", "-p", &oid0]), b"first");
+        assert_eq!(git_in(cwd, &["cat-file", "-p", &oid1]), b"second");
+    }
+
+    #[test]
+    fn re_mirror_replaces_only_the_target_run() {
+        let temp = TempDir::new().unwrap();
+        let cwd = temp.path();
+        let commit = init_git_repo(cwd);
+
+        let factory = InquestRepositoryFactory;
+        let mut repo = factory.initialise(cwd).unwrap();
+
+        let (run0, mut w) = repo.begin_test_run_raw().unwrap();
+        w.write_all(b"first").unwrap();
+        drop(w);
+        let metadata = metadata_for(&commit);
+        mirror_with_cwd(cwd, &*repo, &run0, &metadata, RunTotals::default(), None).unwrap();
+
+        // Manually overwrite the on-disk subunit file so the next mirror
+        // sees different bytes for the same run id.
+        let run0_path = cwd.join(".inquest/runs").join(run0.as_str());
+        std::fs::write(&run0_path, b"replacement").unwrap();
+
+        // Re-mirror run0 — its subunit blob should be rewritten in place.
+        mirror_with_cwd(cwd, &*repo, &run0, &metadata, RunTotals::default(), None).unwrap();
+        let oid0 = lookup_entry(
+            cwd,
+            DEFAULT_MIRROR_REF,
+            &format!("{}/{}/subunit", commit, run0.as_str()),
+        )
+        .unwrap();
+        assert_eq!(git_in(cwd, &["cat-file", "-p", &oid0]), b"replacement");
+    }
+
+    #[test]
+    fn re_mirror_drops_vestigial_stderr() {
+        // First mirror with stderr; second mirror with no stderr should
+        // remove the previous stderr blob from the tree.
+        let temp = TempDir::new().unwrap();
+        let cwd = temp.path();
+        let commit = init_git_repo(cwd);
+
+        let (repo, run_id) = make_repo_with_run(cwd, b"bytes");
+        let metadata = metadata_for(&commit);
+
+        mirror_with_cwd(
+            cwd,
+            &*repo,
+            &run_id,
+            &metadata,
+            RunTotals::default(),
+            Some(b"runner crashed here\n"),
+        )
+        .unwrap();
+        let stderr_path = format!("{}/{}/stderr", commit, run_id.as_str());
+        assert!(
+            lookup_entry(cwd, DEFAULT_MIRROR_REF, &stderr_path).is_some(),
+            "stderr blob should exist after first mirror"
+        );
+
+        mirror_with_cwd(cwd, &*repo, &run_id, &metadata, RunTotals::default(), None).unwrap();
+        assert_eq!(
+            lookup_entry(cwd, DEFAULT_MIRROR_REF, &stderr_path),
+            None,
+            "stderr blob should be gone after re-mirror with no stderr"
+        );
+    }
+
+    #[test]
+    fn empty_stderr_is_omitted() {
+        let temp = TempDir::new().unwrap();
+        let cwd = temp.path();
+        let commit = init_git_repo(cwd);
+
+        let (repo, run_id) = make_repo_with_run(cwd, b"bytes");
+        let metadata = metadata_for(&commit);
+
+        mirror_with_cwd(
+            cwd,
+            &*repo,
+            &run_id,
+            &metadata,
+            RunTotals::default(),
+            Some(b""),
+        )
+        .unwrap();
+        let stderr_path = format!("{}/{}/stderr", commit, run_id.as_str());
+        assert_eq!(lookup_entry(cwd, DEFAULT_MIRROR_REF, &stderr_path), None);
+    }
+
+    #[test]
+    fn stderr_round_trips() {
+        let temp = TempDir::new().unwrap();
+        let cwd = temp.path();
+        let commit = init_git_repo(cwd);
+
+        let (repo, run_id) = make_repo_with_run(cwd, b"bytes");
+        let metadata = metadata_for(&commit);
+        let stderr = b"line one\nline two\n";
+
+        mirror_with_cwd(
+            cwd,
+            &*repo,
+            &run_id,
+            &metadata,
+            RunTotals::default(),
+            Some(stderr),
+        )
+        .unwrap();
+
+        let oid = lookup_entry(
+            cwd,
+            DEFAULT_MIRROR_REF,
+            &format!("{}/{}/stderr", commit, run_id.as_str()),
+        )
+        .expect("stderr entry");
+        assert_eq!(git_in(cwd, &["cat-file", "-p", &oid]), stderr);
+    }
+
+    #[test]
+    fn mirror_is_a_noop_outside_a_git_repo() {
+        let temp = TempDir::new().unwrap();
+        let cwd = temp.path();
+        // Deliberately do *not* `git init`.
+        let payload = b"bytes";
+        let (repo, run_id) = make_repo_with_run(cwd, payload);
+        let metadata = metadata_for("0000000000000000000000000000000000000000");
+        // No error, no panic, no ref created.
+        mirror_with_cwd(cwd, &*repo, &run_id, &metadata, RunTotals::default(), None).unwrap();
+    }
+
+    #[test]
+    fn mirror_is_a_noop_when_git_commit_is_missing() {
+        let temp = TempDir::new().unwrap();
+        let cwd = temp.path();
+        let _commit = init_git_repo(cwd);
+        let (repo, run_id) = make_repo_with_run(cwd, b"bytes");
+        let metadata = RunMetadata::default(); // git_commit: None
+        mirror_with_cwd(cwd, &*repo, &run_id, &metadata, RunTotals::default(), None).unwrap();
+
+        // No mirror ref should have been created.
+        let output = Command::new("git")
+            .args(["rev-parse", "--verify", DEFAULT_MIRROR_REF])
+            .current_dir(cwd)
+            .output()
+            .unwrap();
+        assert!(
+            !output.status.success(),
+            "mirror ref unexpectedly exists: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+
+    #[test]
+    fn run_totals_from_run_counts_correctly() {
+        let mut run = TestRun::new(RunId::new("0"));
+        run.add_result(TestResult {
+            test_id: TestId::new("a"),
+            status: TestStatus::Success,
+            duration: None,
+            message: None,
+            details: None,
+            tags: vec![],
+        });
+        run.add_result(TestResult {
+            test_id: TestId::new("b"),
+            status: TestStatus::Failure,
+            duration: None,
+            message: None,
+            details: None,
+            tags: vec![],
+        });
+        run.add_result(TestResult {
+            test_id: TestId::new("c"),
+            status: TestStatus::Error,
+            duration: None,
+            message: None,
+            details: None,
+            tags: vec![],
+        });
+        run.add_result(TestResult {
+            test_id: TestId::new("d"),
+            status: TestStatus::Skip,
+            duration: None,
+            message: None,
+            details: None,
+            tags: vec![],
+        });
+        let totals = RunTotals::from_run(&run);
+        assert_eq!(totals.total, 4);
+        assert_eq!(totals.failures, 1);
+        assert_eq!(totals.errors, 1);
+        assert_eq!(totals.skips, 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub mod commands;
 pub mod config;
 pub mod error;
 pub mod eta;
+pub mod git_notes;
 pub mod grouping;
 #[cfg(feature = "mcp")]
 pub mod mcp;


### PR DESCRIPTION
This opens the door for in the future pushing and pulling test results.