### PR TITLE
Suppress slow-test warnings on sub-100ms tests

### DIFF
--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -327,6 +327,9 @@ pub fn warn_slow_tests(
                 return None;
             }
             let historical = historical_times.get(&result.test_id)?;
+            if *historical < SLOW_TEST_WARNING_MIN_DURATION {
+                return None;
+            }
             let threshold = std::time::Duration::from_secs_f64(
                 historical.as_secs_f64() * SLOW_TEST_WARNING_MULTIPLIER,
             );
@@ -644,6 +647,25 @@ mod tests {
         historical.insert(
             crate::repository::TestId::new("fast_test"),
             std::time::Duration::from_micros(10),
+        );
+        warn_slow_tests(&mut ui, &run, &historical).unwrap();
+        assert!(ui.output.is_empty());
+    }
+
+    #[test]
+    fn test_warn_slow_tests_ignores_tiny_historical() {
+        // A test with a near-zero historical average shouldn't generate a warning
+        // even if the current run exceeds the multiplier — the ratios are noise.
+        let mut ui = crate::ui::test_ui::TestUI::new();
+        let mut run = crate::repository::TestRun::new(crate::repository::RunId::new("0"));
+        run.add_result(
+            crate::repository::TestResult::success("blip")
+                .with_duration(std::time::Duration::from_secs(1)),
+        );
+        let mut historical = std::collections::HashMap::new();
+        historical.insert(
+            crate::repository::TestId::new("blip"),
+            std::time::Duration::from_micros(50),
         );
         warn_slow_tests(&mut ui, &run, &historical).unwrap();
         assert!(ui.output.is_empty());

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,9 +39,11 @@ pub const MAX_TEST_RESTARTS: usize = 10;
 pub const SLOW_TEST_WARNING_MULTIPLIER: f64 = 3.0;
 
 /// Minimum absolute duration for a test to be considered for slow-test warnings.
-/// Tests faster than this are treated as noise even if they exceed the multiplier,
-/// since small absolute variations produce huge ratios on sub-second tests.
-pub const SLOW_TEST_WARNING_MIN_DURATION: std::time::Duration = std::time::Duration::from_millis(2);
+/// Both the current and historical durations must clear this floor; otherwise
+/// tiny absolute variations produce huge (or infinite) ratios on sub-second
+/// tests and the warning is just noise.
+pub const SLOW_TEST_WARNING_MIN_DURATION: std::time::Duration =
+    std::time::Duration::from_millis(100);
 
 /// Timeout configuration that supports "disabled", "auto", or an explicit duration.
 ///


### PR DESCRIPTION
Raise the floor from 2ms to 100ms and require both the current and historical durations to clear it. Otherwise jitter on near-zero tests produces noisy "0.0s (was 0.0s, infx slower)" warnings.