### PR TITLE
Add inq shard for distributed CI sharding

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,13 @@ UNRELEASED
 CHANGES
 -------
 
+* Add ``inq shard <N/M>`` for distributed CI sharding. Each node calls
+  ``inq shard N/M`` to print a load-balanced, disjoint slice of the
+  suite, balanced by historical per-test durations (or round-robin when
+  no history exists). Honours ``group_regex`` so related tests stay on
+  the same shard. The partition is deterministic across machines, so
+  the union of all shards equals the full suite. (Jelmer Vernooĳ)
+
 * Add support for named **profiles** in ``inquest.toml``. Top-level
   fields form the implicit base layer; ``[profiles.<name>]`` tables
   declare overlayable variants. Select one with ``inq --profile NAME``,

--- a/README.md
+++ b/README.md
@@ -211,6 +211,34 @@ Example:
 inq log 'test.module.TestCase.*'
 ```
 
+### `inq shard <N/M>`
+
+Print the test IDs assigned to one shard of an `M`-way balanced split.
+Distributed CI nodes can each call `inq shard N/M` to claim a disjoint,
+load-balanced slice of the suite. Historical durations from the repository
+are used to balance shards when available; without history, the split
+degrades to round-robin.
+
+The partition is deterministic given the same suite and history, so two
+nodes calling `inq shard 1/4` and `inq shard 2/4` produce disjoint shards
+whose union is the full suite.
+
+Options:
+- `--group-regex <REGEX>`: Override the config's `group_regex`. Pass an
+  empty string to disable grouping for this command only.
+- `--zero-indexed`: Treat the shard index as 0-based (i.e. `0/4..3/4`).
+
+Example (GitHub Actions matrix):
+
+```yaml
+strategy:
+  matrix:
+    shard: [1, 2, 3, 4]
+steps:
+  - run: inq shard ${{ matrix.shard }}/4 > shard.txt
+  - run: inq run --load-list shard.txt
+```
+
 ### `inq prune`
 
 Drop older test runs from the repository. Exactly one selection mode must be

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -25,6 +25,7 @@ pub mod quickstart;
 pub mod rerun;
 pub mod run;
 pub mod running;
+pub mod shard;
 pub mod slowest;
 pub mod stats;
 #[cfg(feature = "testr")]
@@ -54,6 +55,7 @@ pub use quickstart::QuickstartCommand;
 pub use rerun::RerunCommand;
 pub use run::RunCommand;
 pub use running::RunningCommand;
+pub use shard::ShardCommand;
 pub use slowest::SlowestCommand;
 pub use stats::StatsCommand;
 #[cfg(feature = "testr")]

--- a/src/commands/shard.rs
+++ b/src/commands/shard.rs
@@ -1,0 +1,321 @@
+//! Print the test IDs assigned to one shard of a balanced split.
+//!
+//! `inq shard N/M` discovers the suite, partitions it across M shards using
+//! the same duration-aware greedy algorithm as parallel runs, and prints the
+//! IDs for shard N. Distributed CI nodes call this once each to claim a
+//! disjoint, load-balanced slice of the suite. The historical durations
+//! recorded in the repository are used when available; without history, the
+//! split degrades to round-robin.
+
+use crate::commands::utils::open_repository;
+use crate::commands::Command;
+use crate::error::{Error, Result};
+use crate::partition::partition_tests_with_grouping;
+use crate::repository::TestId;
+use crate::testcommand::TestCommand;
+use crate::ui::UI;
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::Duration;
+
+/// Print the test IDs assigned to one shard of an `M`-way balanced split.
+///
+/// The partition is deterministic given the same suite and history, so two
+/// nodes calling `inq shard 1/4` and `inq shard 2/4` produce disjoint shards
+/// whose union is the full suite.
+pub struct ShardCommand {
+    base_path: Option<String>,
+    /// 0-based shard index (resolved from the user-supplied `N/M`).
+    shard: usize,
+    /// Total number of shards.
+    total: usize,
+    /// Override for the config's `group_regex`. Empty string disables grouping.
+    group_regex: Option<String>,
+}
+
+impl ShardCommand {
+    /// Build a shard command from a parsed shard index, total count, and an
+    /// optional group-regex override.
+    pub fn new(
+        base_path: Option<String>,
+        shard: usize,
+        total: usize,
+        group_regex: Option<String>,
+    ) -> Self {
+        ShardCommand {
+            base_path,
+            shard,
+            total,
+            group_regex,
+        }
+    }
+
+    /// Parse the `N/M` spec. Accepts 1-based input by default; with
+    /// `zero_indexed = true` the first shard is `0/M`.
+    ///
+    /// Returns the 0-based shard index along with the total.
+    pub fn parse_spec(spec: &str, zero_indexed: bool) -> Result<(usize, usize)> {
+        let (n_str, m_str) = spec.split_once('/').ok_or_else(|| {
+            Error::Config(format!(
+                "invalid shard spec '{}': expected N/M (e.g. 1/4)",
+                spec
+            ))
+        })?;
+        let n: usize = n_str.trim().parse().map_err(|_| {
+            Error::Config(format!(
+                "invalid shard spec '{}': N must be a non-negative integer",
+                spec
+            ))
+        })?;
+        let m: usize = m_str.trim().parse().map_err(|_| {
+            Error::Config(format!(
+                "invalid shard spec '{}': M must be a non-negative integer",
+                spec
+            ))
+        })?;
+        if m == 0 {
+            return Err(Error::Config(format!(
+                "invalid shard spec '{}': M must be at least 1",
+                spec
+            )));
+        }
+        let index = if zero_indexed {
+            if n >= m {
+                return Err(Error::Config(format!(
+                    "invalid shard spec '{}': N must be in 0..{} when --zero-indexed",
+                    spec, m
+                )));
+            }
+            n
+        } else {
+            if n == 0 || n > m {
+                return Err(Error::Config(format!(
+                    "invalid shard spec '{}': N must be in 1..={}",
+                    spec, m
+                )));
+            }
+            n - 1
+        };
+        Ok((index, m))
+    }
+}
+
+/// Compute the test IDs assigned to one shard of an `M`-way balanced split.
+///
+/// Sorts `test_ids` deterministically before partitioning so distributed
+/// callers see the same layout. Returns an error for an out-of-range shard
+/// index or an invalid `group_regex`.
+pub fn compute_shard(
+    test_ids: &[TestId],
+    durations: &HashMap<TestId, Duration>,
+    shard: usize,
+    total: usize,
+    group_regex: Option<&str>,
+) -> Result<Vec<TestId>> {
+    let mut sorted = test_ids.to_vec();
+    sorted.sort();
+    let partitions = partition_tests_with_grouping(&sorted, durations, total, group_regex)
+        .map_err(|e| Error::Config(format!("invalid group_regex: {}", e)))?;
+    partitions
+        .into_iter()
+        .nth(shard)
+        .ok_or_else(|| Error::Config(format!("shard index {} out of range", shard)))
+}
+
+impl Command for ShardCommand {
+    fn execute(&self, ui: &mut dyn UI) -> Result<i32> {
+        let base = self
+            .base_path
+            .as_deref()
+            .map_or_else(|| Path::new("."), Path::new);
+
+        let test_cmd = TestCommand::from_directory(base)?;
+        let test_ids = test_cmd.list_tests()?;
+
+        // Pull historical durations if a repository exists. Sharding works
+        // without one — the partition just degrades to round-robin.
+        let durations: HashMap<TestId, Duration> = open_repository(self.base_path.as_deref())
+            .ok()
+            .and_then(|repo| repo.get_test_times().ok())
+            .unwrap_or_default();
+
+        // CLI override (including empty string to disable) wins over config.
+        let configured_group_regex = test_cmd.config().group_regex.clone();
+        let group_regex: Option<String> = match &self.group_regex {
+            Some(r) if r.is_empty() => None,
+            Some(r) => Some(r.clone()),
+            None => configured_group_regex,
+        };
+
+        let shard = compute_shard(
+            &test_ids,
+            &durations,
+            self.shard,
+            self.total,
+            group_regex.as_deref(),
+        )?;
+
+        for id in shard {
+            ui.output(id.as_str())?;
+        }
+        Ok(0)
+    }
+
+    fn name(&self) -> &str {
+        "shard"
+    }
+
+    fn help(&self) -> &str {
+        "Print the test IDs assigned to one shard of a balanced split"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_spec_one_based() {
+        assert_eq!(ShardCommand::parse_spec("1/4", false).unwrap(), (0, 4));
+        assert_eq!(ShardCommand::parse_spec("4/4", false).unwrap(), (3, 4));
+    }
+
+    #[test]
+    fn parse_spec_zero_based() {
+        assert_eq!(ShardCommand::parse_spec("0/4", true).unwrap(), (0, 4));
+        assert_eq!(ShardCommand::parse_spec("3/4", true).unwrap(), (3, 4));
+    }
+
+    #[test]
+    fn parse_spec_rejects_zero_when_one_based() {
+        assert!(ShardCommand::parse_spec("0/4", false).is_err());
+    }
+
+    #[test]
+    fn parse_spec_rejects_index_at_or_above_total_when_zero_based() {
+        assert!(ShardCommand::parse_spec("4/4", true).is_err());
+    }
+
+    #[test]
+    fn parse_spec_rejects_index_above_total_one_based() {
+        assert!(ShardCommand::parse_spec("5/4", false).is_err());
+    }
+
+    #[test]
+    fn parse_spec_rejects_zero_total() {
+        assert!(ShardCommand::parse_spec("1/0", false).is_err());
+        assert!(ShardCommand::parse_spec("0/0", true).is_err());
+    }
+
+    #[test]
+    fn parse_spec_rejects_missing_slash() {
+        assert!(ShardCommand::parse_spec("4", false).is_err());
+    }
+
+    #[test]
+    fn parse_spec_rejects_non_numeric() {
+        assert!(ShardCommand::parse_spec("a/4", false).is_err());
+        assert!(ShardCommand::parse_spec("1/b", false).is_err());
+    }
+
+    fn make_tests(ids: &[&str]) -> Vec<TestId> {
+        ids.iter().map(|s| TestId::new(*s)).collect()
+    }
+
+    #[test]
+    fn compute_shard_union_covers_all_tests_no_duplicates() {
+        let tests = make_tests(&[
+            "a::t1", "a::t2", "a::t3", "b::t1", "b::t2", "c::t1", "d::t1", "e::t1",
+        ]);
+        let durations = HashMap::new();
+        let total = 3;
+
+        let mut union: Vec<TestId> = Vec::new();
+        for shard in 0..total {
+            let part = compute_shard(&tests, &durations, shard, total, None).unwrap();
+            union.extend(part);
+        }
+        union.sort();
+
+        let mut expected = tests.clone();
+        expected.sort();
+        assert_eq!(union, expected);
+    }
+
+    #[test]
+    fn compute_shard_is_deterministic_under_input_reordering() {
+        // The same suite given in two different orders should produce the
+        // same shard for any given index. This is what makes `inq shard`
+        // safe to call from CI nodes whose discovery order may vary.
+        let tests_a = make_tests(&["alpha::a", "beta::b", "gamma::c", "delta::d"]);
+        let tests_b = make_tests(&["delta::d", "gamma::c", "beta::b", "alpha::a"]);
+        let durations = HashMap::new();
+
+        for shard in 0..2 {
+            let part_a = compute_shard(&tests_a, &durations, shard, 2, None).unwrap();
+            let part_b = compute_shard(&tests_b, &durations, shard, 2, None).unwrap();
+            assert_eq!(part_a, part_b);
+        }
+    }
+
+    #[test]
+    fn compute_shard_balances_by_duration() {
+        let tests = make_tests(&["fast1", "fast2", "slow1", "slow2"]);
+        let mut durations = HashMap::new();
+        durations.insert(TestId::new("fast1"), Duration::from_millis(100));
+        durations.insert(TestId::new("fast2"), Duration::from_millis(100));
+        durations.insert(TestId::new("slow1"), Duration::from_secs(5));
+        durations.insert(TestId::new("slow2"), Duration::from_secs(5));
+
+        let s0 = compute_shard(&tests, &durations, 0, 2, None).unwrap();
+        let s1 = compute_shard(&tests, &durations, 1, 2, None).unwrap();
+
+        // Each shard ends up with exactly one slow + one fast, not two slows.
+        let dur =
+            |part: &[TestId]| -> Duration { part.iter().filter_map(|id| durations.get(id)).sum() };
+        assert!(dur(&s0).abs_diff(dur(&s1)) < Duration::from_millis(500));
+    }
+
+    #[test]
+    fn compute_shard_respects_group_regex() {
+        let tests = make_tests(&[
+            "modA::test_a",
+            "modA::test_b",
+            "modA::test_c",
+            "modB::test_d",
+        ]);
+        let durations = HashMap::new();
+        let group = Some(r"^([^:]+)::");
+
+        let s0 = compute_shard(&tests, &durations, 0, 2, group).unwrap();
+        let s1 = compute_shard(&tests, &durations, 1, 2, group).unwrap();
+
+        // Same module's tests must not be split across shards.
+        let module_of = |t: &TestId| t.as_str().split("::").next().unwrap().to_string();
+        let modules_in = |part: &[TestId]| -> std::collections::HashSet<String> {
+            part.iter().map(module_of).collect()
+        };
+        let m0 = modules_in(&s0);
+        let m1 = modules_in(&s1);
+        assert!(
+            m0.is_disjoint(&m1),
+            "shards split a module: {:?} vs {:?}",
+            m0,
+            m1
+        );
+    }
+
+    #[test]
+    fn compute_shard_out_of_range_errors() {
+        let tests = make_tests(&["a", "b", "c"]);
+        let durations = HashMap::new();
+        assert!(compute_shard(&tests, &durations, 4, 4, None).is_err());
+    }
+
+    #[test]
+    fn compute_shard_invalid_regex_errors() {
+        let tests = make_tests(&["a", "b"]);
+        let durations = HashMap::new();
+        assert!(compute_shard(&tests, &durations, 0, 2, Some("^(unclosed")).is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use inquest::error::Result;
 use inquest::ui::UI;
 
 // Explicit imports for commands not covered by wildcard
-use inquest::commands::{AnalyzeIsolationCommand, BisectCommand};
+use inquest::commands::{AnalyzeIsolationCommand, BisectCommand, ShardCommand};
 
 #[derive(Parser)]
 #[command(name = "inq")]
@@ -225,6 +225,23 @@ enum Commands {
     /// List all available tests
     #[command(name = "list-tests")]
     ListTests,
+
+    /// Print the test IDs assigned to one shard of a balanced split
+    Shard {
+        /// Shard spec as N/M (e.g. "1/4" picks shard 1 of 4). N is 1-based by
+        /// default; pass --zero-indexed to use 0..M-1 instead.
+        #[arg(value_name = "N/M")]
+        spec: String,
+
+        /// Override the config's group_regex. Pass an empty string to disable
+        /// grouping for this command only.
+        #[arg(long, value_name = "REGEX")]
+        group_regex: Option<String>,
+
+        /// Treat the shard index as 0-based instead of 1-based
+        #[arg(long)]
+        zero_indexed: bool,
+    },
 
     /// Drop older test runs from the repository
     Prune {
@@ -634,6 +651,20 @@ fn main() {
             let cmd = ListTestsCommand::new(cli.directory);
             cmd.execute(&mut ui)
         }
+        Commands::Shard {
+            spec,
+            group_regex,
+            zero_indexed,
+        } => match ShardCommand::parse_spec(&spec, zero_indexed) {
+            Ok((shard, total)) => {
+                let cmd = ShardCommand::new(cli.directory, shard, total, group_regex);
+                cmd.execute(&mut ui)
+            }
+            Err(e) => {
+                tracing::error!("{}", e);
+                std::process::exit(1);
+            }
+        },
         Commands::Prune {
             keep,
             older_than,

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -49,8 +49,10 @@ pub fn partition_tests(
         }
     }
 
-    // Sort tests with durations from longest to shortest
-    with_duration.sort_by_key(|b| std::cmp::Reverse(b.1));
+    // Sort tests with durations from longest to shortest. Tie-break by test ID
+    // so the partition layout is deterministic across machines (used by
+    // `inq shard` to keep distributed CI nodes consistent).
+    with_duration.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
 
     // Initialize partitions with expected runtime tracking
     let mut partitions: Vec<(Vec<TestId>, Duration)> = (0..concurrency)
@@ -126,8 +128,10 @@ pub fn partition_tests_with_grouping(
         })
         .collect();
 
-    // Sort groups by duration (longest first)
-    group_durations.sort_by_key(|b| std::cmp::Reverse(b.2));
+    // Sort groups by duration (longest first). Tie-break by group name so the
+    // partition layout is deterministic across machines (used by `inq shard`
+    // to keep distributed CI nodes consistent).
+    group_durations.sort_by(|a, b| b.2.cmp(&a.2).then_with(|| a.0.cmp(&b.0)));
 
     // Initialize partitions
     let mut partitions: Vec<(Vec<TestId>, Duration)> = (0..concurrency)
@@ -335,6 +339,33 @@ mod tests {
         // One should be ~10s (slow module), other ~0.2s (fast module)
         let total_duration = partition0_duration + partition1_duration;
         assert_eq!(total_duration.as_millis(), 10200);
+    }
+
+    #[test]
+    fn test_partition_is_deterministic_with_equal_durations() {
+        // Several tests share the same duration, so the greedy LPT algorithm
+        // can hit ties at every step. Without a stable tie-breaker the layout
+        // would depend on insertion order; with one, two callers see the same
+        // partitions. This is what makes `inq shard` work across machines.
+        let tests: Vec<TestId> = (0..8).map(|i| TestId::new(format!("t{}", i))).collect();
+        let mut durations = HashMap::new();
+        for t in &tests {
+            durations.insert(t.clone(), Duration::from_secs(1));
+        }
+        let a = partition_tests(&tests, &durations, 4);
+        let b = partition_tests(&tests, &durations, 4);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_partition_with_grouping_is_deterministic() {
+        let tests: Vec<TestId> = (0..6)
+            .map(|i| TestId::new(format!("mod{}.test_a", i)))
+            .collect();
+        let durations = HashMap::new();
+        let a = partition_tests_with_grouping(&tests, &durations, 3, Some(r"^([^.]+)\.")).unwrap();
+        let b = partition_tests_with_grouping(&tests, &durations, 3, Some(r"^([^.]+)\.")).unwrap();
+        assert_eq!(a, b);
     }
 
     #[test]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -266,6 +266,42 @@ test_timeout = "10m"
 }
 
 #[test]
+fn shard_help_documents_spec_and_options() {
+    let out = Command::new(inq_bin())
+        .arg("shard")
+        .arg("--help")
+        .output()
+        .expect("run inq shard --help");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("<N/M>"),
+        "expected <N/M> placeholder: {stdout}"
+    );
+    assert!(
+        stdout.contains("--group-regex"),
+        "expected --group-regex flag: {stdout}"
+    );
+    assert!(
+        stdout.contains("--zero-indexed"),
+        "expected --zero-indexed flag: {stdout}"
+    );
+}
+
+#[test]
+fn shard_rejects_invalid_spec() {
+    let temp = TempDir::new().unwrap();
+    let out = Command::new(inq_bin())
+        .arg("-C")
+        .arg(temp.path())
+        .arg("shard")
+        .arg("not-a-spec")
+        .output()
+        .expect("run inq shard");
+    assert!(!out.status.success());
+}
+
+#[test]
 fn flat_config_still_works_unchanged() {
     // Backwards-compat smoke test: a flat config (no profiles, no
     // default_profile) loads and resolves with no profile annotations.


### PR DESCRIPTION
Each CI node calls `inq shard N/M` and gets a load-balanced, disjoint slice of the suite, balanced by historical per-test durations from the repository (or round-robin when no history exists). The partition is the same one parallel runs use, so honouring `group_regex` keeps related tests on the same shard.