### PR TITLE
Extract resolve_concurrency to fix MCP background runs ignoring config

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -441,7 +441,10 @@ impl RunCommand {
                 }
             }
             crate::testcommand::ConcurrencySource::ConfigCallout(c) => {
-                ui.output(&format!("Using concurrency from test_run_concurrency: {}", c))?;
+                ui.output(&format!(
+                    "Using concurrency from test_run_concurrency: {}",
+                    c
+                ))?;
             }
             crate::testcommand::ConcurrencySource::Default => {
                 suggest_parallel_for_explicit_run(ui, &test_ids, &historical_times)?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -424,35 +424,30 @@ impl RunCommand {
             );
         }
 
-        let concurrency = if let Some(explicit_concurrency) = self.concurrency {
-            if explicit_concurrency == 0 {
-                let cpu_count = num_cpus::get();
+        let (concurrency, concurrency_source) = test_cmd.resolve_concurrency(self.concurrency)?;
+        match &concurrency_source {
+            crate::testcommand::ConcurrencySource::AutoDetected(cpus) => {
                 if self.implicit_run {
                     ui.output(&format!(
                         "Running in parallel mode across {} CPUs (auto-detected). \
                          Run `inq run` to disable parallel mode, or `inq run -j N` to set a specific worker count.",
-                        cpu_count
+                        cpus
                     ))?;
                 } else {
                     ui.output(&format!(
                         "Auto-detected {} CPUs for parallel execution",
-                        cpu_count
+                        cpus
                     ))?;
                 }
-                cpu_count
-            } else {
-                explicit_concurrency
             }
-        } else if let Some(callout_concurrency) = test_cmd.get_concurrency()? {
-            ui.output(&format!(
-                "Using concurrency from test_run_concurrency: {}",
-                callout_concurrency
-            ))?;
-            callout_concurrency
-        } else {
-            suggest_parallel_for_explicit_run(ui, &test_ids, &historical_times)?;
-            1
-        };
+            crate::testcommand::ConcurrencySource::ConfigCallout(c) => {
+                ui.output(&format!("Using concurrency from test_run_concurrency: {}", c))?;
+            }
+            crate::testcommand::ConcurrencySource::Default => {
+                suggest_parallel_for_explicit_run(ui, &test_ids, &historical_times)?;
+            }
+            crate::testcommand::ConcurrencySource::Explicit => {}
+        }
 
         let calibration_debug =
             crate::eta::calibration_debug(&calibration_samples, concurrency as u32);

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1702,7 +1702,9 @@ impl InquestMcpService {
                 );
             }
 
-            let concurrency = params.concurrency.unwrap_or(1);
+            let (concurrency, _source) = test_cmd
+                .resolve_concurrency(params.concurrency)
+                .map_err(to_mcp_err)?;
             let calibration_factor =
                 crate::eta::calibration_factor(&calibration_samples, concurrency as u32);
 

--- a/src/testcommand.rs
+++ b/src/testcommand.rs
@@ -23,6 +23,19 @@ fn sh_command(cmd_str: &str, working_dir: &Path) -> Command {
     cmd
 }
 
+/// Describes where the resolved concurrency value came from.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ConcurrencySource {
+    /// Explicitly provided by the caller.
+    Explicit,
+    /// Auto-detected from the number of CPUs.
+    AutoDetected(usize),
+    /// From the `test_run_concurrency` config callout.
+    ConfigCallout(usize),
+    /// Default value (1).
+    Default,
+}
+
 /// Test command executor
 #[derive(Debug)]
 pub struct TestCommand {
@@ -100,6 +113,26 @@ impl TestCommand {
         }
 
         Ok(Some(concurrency))
+    }
+
+    /// Resolve the effective concurrency level.
+    ///
+    /// Priority: explicit value > config callout > default of 1.
+    /// A value of 0 means auto-detect (number of CPUs).
+    ///
+    /// Returns (concurrency, source) where source describes where the value came from.
+    pub fn resolve_concurrency(&self, explicit: Option<usize>) -> Result<(usize, ConcurrencySource)> {
+        if let Some(0) = explicit {
+            let cpus = num_cpus::get();
+            return Ok((cpus, ConcurrencySource::AutoDetected(cpus)));
+        }
+        if let Some(c) = explicit {
+            return Ok((c, ConcurrencySource::Explicit));
+        }
+        if let Some(c) = self.get_concurrency()? {
+            return Ok((c, ConcurrencySource::ConfigCallout(c)));
+        }
+        Ok((1, ConcurrencySource::Default))
     }
 
     /// Build the command to execute tests

--- a/src/testcommand.rs
+++ b/src/testcommand.rs
@@ -121,7 +121,10 @@ impl TestCommand {
     /// A value of 0 means auto-detect (number of CPUs).
     ///
     /// Returns (concurrency, source) where source describes where the value came from.
-    pub fn resolve_concurrency(&self, explicit: Option<usize>) -> Result<(usize, ConcurrencySource)> {
+    pub fn resolve_concurrency(
+        &self,
+        explicit: Option<usize>,
+    ) -> Result<(usize, ConcurrencySource)> {
         if let Some(0) = explicit {
             let cpus = num_cpus::get();
             return Ok((cpus, ConcurrencySource::AutoDetected(cpus)));


### PR DESCRIPTION
The MCP background run path hardcoded concurrency to 1, ignoring both the test_run_concurrency config callout and concurrency=0 (auto-detect). Extract the resolution logic into TestCommand::resolve_concurrency() and use it from both the CLI and MCP paths.