### PR TITLE
testcommand: Shell-quote $IDFILE substitution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,7 @@ dependencies = [
  "serde",
  "serde_ini",
  "serde_json",
+ "shlex",
  "subunit",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ chrono = { version = "0.4", features = ["serde"] }
 subunit = "0.3.0"
 tempfile = "3.13"
 regex = "1.0"
+shlex = "1"
 glob = "0.3"
 memmap2 = "0.9"
 num_cpus = "1.16"

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,18 @@
 inquest release notes
 #######################
 
+UNRELEASED
+++++++++++
+
+BUG FIXES
+---------
+
+* Fix ``$IDFILE`` substitution on Windows: the temp file path is now
+  shell-quoted before being spliced into the test command, so
+  backslash-separated Windows paths survive the ``sh -c`` re-parse
+  instead of being mangled and causing every worker to fail with
+  ``FileNotFoundError``. (Jelmer Vernooĳ)
+
 0.3.4	2026-07-05
 ++++++++++++++++++
 

--- a/src/testcommand.rs
+++ b/src/testcommand.rs
@@ -211,7 +211,19 @@ impl TestCommand {
                     })?;
                 }
 
-                let temp_path = temp.path().to_string_lossy().to_string();
+                // Quote for `sh -c` re-parsing; Windows temp paths contain
+                // backslashes that `sh` would otherwise eat as escapes.
+                let temp_path_raw = temp.path().to_str().ok_or_else(|| {
+                    Error::CommandExecution(format!(
+                        "IDFILE path is not valid UTF-8: {}",
+                        temp.path().display()
+                    ))
+                })?;
+                let temp_path = shlex::try_quote(temp_path_raw)
+                    .map_err(|e| {
+                        Error::CommandExecution(format!("Failed to quote IDFILE path: {}", e))
+                    })?
+                    .into_owned();
                 vars.insert("IDFILE".to_string(), temp_path);
 
                 // Handle IDOPTION
@@ -593,11 +605,26 @@ test_list_option=--list
         assert!(cmd.starts_with("python -m subunit.run  --load-list "));
         assert!(temp_file.is_some());
 
-        // Verify temp file contents
-        if let Some(temp) = temp_file {
-            let contents = fs::read_to_string(temp.path()).unwrap();
-            assert_eq!(contents, "test1\ntest2\n");
-        }
+        let temp = temp_file.unwrap();
+        let tokens = shlex::split(&cmd).expect("command should parse as shell tokens");
+        let load_list_idx = tokens
+            .iter()
+            .position(|t| t == "--load-list")
+            .expect("--load-list not found");
+        assert_eq!(tokens[load_list_idx + 1], temp.path().to_str().unwrap());
+
+        let contents = fs::read_to_string(temp.path()).unwrap();
+        assert_eq!(contents, "test1\ntest2\n");
+    }
+
+    #[test]
+    fn test_windows_style_idfile_survives_sh_parse() {
+        let win_path = r"C:\Users\RUNNER~1\AppData\Local\Temp\.tmpABC123";
+        let quoted = shlex::try_quote(win_path).unwrap();
+        let cmd = format!("python -m subunit.run --load-list {}", quoted);
+        let tokens = shlex::split(&cmd).expect("command should parse");
+        let idx = tokens.iter().position(|t| t == "--load-list").unwrap();
+        assert_eq!(tokens[idx + 1], win_path);
     }
 
     #[test]


### PR DESCRIPTION
`inq` executes the resolved test command via `sh -c <cmd>`, so any substituted value must survive shell re-parsing. On Windows, `NamedTempFile` produces backslash-separated paths like `C:\Users\RUNNER~1\AppData\Local\Temp\.tmpXYZ`, which `sh` reads as escape sequences and strips, leaving `C:UsersRUNNER~1...tmpXYZ`. Every worker then dies with `FileNotFoundError` and the run reports `Total: 0, Passed: 0, Failed: 0`.
